### PR TITLE
test(kit): add unit tests for zero-coverage modules (#39)

### DIFF
--- a/packages/kit/src/db/manager.test.ts
+++ b/packages/kit/src/db/manager.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockDrizzle, mockWithReplicas, mockUseCzoConfig } = vi.hoisted(() => ({
+  mockDrizzle: vi.fn().mockReturnValue({ _type: 'masterDb' }),
+  mockWithReplicas: vi.fn().mockImplementation((master: any, replicas: any) => ({
+    _type: 'replicaDb',
+    master,
+    replicas,
+  })),
+  mockUseCzoConfig: vi.fn(),
+}))
+
+vi.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: mockDrizzle,
+}))
+
+vi.mock('drizzle-orm/pg-core', () => ({
+  withReplicas: mockWithReplicas,
+}))
+
+vi.mock('../config', () => ({
+  useCzoConfig: mockUseCzoConfig,
+}))
+
+describe('useDatabase', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockDrizzle.mockClear().mockReturnValue({ _type: 'masterDb' })
+    mockWithReplicas.mockClear().mockImplementation((master: any, replicas: any) => ({
+      _type: 'replicaDb',
+      master,
+      replicas,
+    }))
+    mockUseCzoConfig.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should throw when databaseUrl is empty', async () => {
+    mockUseCzoConfig.mockReturnValue({ databaseUrl: '' })
+    const { useDatabase } = await import('./manager')
+
+    expect(() => useDatabase()).toThrow('Database URL is required')
+  })
+
+  it('should throw when databaseUrl is undefined', async () => {
+    mockUseCzoConfig.mockReturnValue({ databaseUrl: undefined })
+    const { useDatabase } = await import('./manager')
+
+    expect(() => useDatabase()).toThrow('Database URL is required')
+  })
+
+  it('should create a master-only DB with a single URL', async () => {
+    mockUseCzoConfig.mockReturnValue({
+      databaseUrl: 'postgresql://localhost/mydb',
+    })
+    const { useDatabase } = await import('./manager')
+
+    const db = useDatabase()
+
+    expect(mockDrizzle).toHaveBeenCalledWith('postgresql://localhost/mydb', undefined)
+    expect(mockWithReplicas).not.toHaveBeenCalled()
+    expect(db).toEqual({ _type: 'masterDb' })
+  })
+
+  it('should create master + replicas with comma-separated URLs', async () => {
+    mockUseCzoConfig.mockReturnValue({
+      databaseUrl: 'postgresql://master/db,postgresql://replica1/db,postgresql://replica2/db',
+    })
+    const replicaDb1 = { _type: 'replica1' }
+    const replicaDb2 = { _type: 'replica2' }
+    mockDrizzle
+      .mockReturnValueOnce({ _type: 'masterDb' })
+      .mockReturnValueOnce(replicaDb1)
+      .mockReturnValueOnce(replicaDb2)
+
+    const { useDatabase } = await import('./manager')
+    const db = useDatabase()
+
+    expect(mockDrizzle).toHaveBeenCalledTimes(3)
+    expect(mockWithReplicas).toHaveBeenCalledWith(
+      { _type: 'masterDb' },
+      [replicaDb1, replicaDb2],
+    )
+    expect(db).toHaveProperty('_type', 'replicaDb')
+  })
+
+  it('should return cached instance on repeated calls (singleton)', async () => {
+    mockUseCzoConfig.mockReturnValue({
+      databaseUrl: 'postgresql://localhost/mydb',
+    })
+    const { useDatabase } = await import('./manager')
+
+    const first = useDatabase()
+    const second = useDatabase()
+
+    expect(first).toBe(second)
+    expect(mockDrizzle).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reset instance when called with explicit config', async () => {
+    mockUseCzoConfig.mockReturnValue({
+      databaseUrl: 'postgresql://localhost/mydb',
+    })
+    // Return distinct objects so we can verify identity
+    mockDrizzle
+      .mockReturnValueOnce({ _type: 'masterDb', call: 1 })
+      .mockReturnValueOnce({ _type: 'masterDb', call: 2 })
+
+    const { useDatabase } = await import('./manager')
+
+    const first = useDatabase()
+    const second = useDatabase({ schema: {} as any })
+
+    expect(first).not.toBe(second)
+    expect(mockDrizzle).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/kit/src/graphql/resolvers.test.ts
+++ b/packages/kit/src/graphql/resolvers.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('graphql/resolvers', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('should return an empty array by default', async () => {
+    const { registeredResolvers } = await import('./resolvers')
+    expect(registeredResolvers()).toEqual([])
+  })
+
+  it('should accumulate resolvers via registerResolvers()', async () => {
+    const { registerResolvers, registeredResolvers } = await import('./resolvers')
+
+    const resolver1 = { Query: { hello: () => 'world' } }
+    registerResolvers(resolver1)
+
+    expect(registeredResolvers()).toHaveLength(1)
+    expect(registeredResolvers()[0]).toBe(resolver1)
+  })
+
+  it('should accumulate multiple registrations', async () => {
+    const { registerResolvers, registeredResolvers } = await import('./resolvers')
+
+    registerResolvers({ Query: { a: () => 1 } })
+    registerResolvers({ Mutation: { b: () => 2 } })
+    registerResolvers({ Query: { c: () => 3 } })
+
+    expect(registeredResolvers()).toHaveLength(3)
+  })
+})

--- a/packages/kit/src/graphql/types.test.ts
+++ b/packages/kit/src/graphql/types.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('graphql/types', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('should include default Query and Mutation type defs', async () => {
+    const { registeredTypeDefs } = await import('./types')
+    const defs = registeredTypeDefs()
+
+    expect(defs).toHaveLength(1)
+    expect(defs[0]).toContain('type Query')
+    expect(defs[0]).toContain('type Mutation')
+  })
+
+  it('should append type defs via registerTypeDefs()', async () => {
+    const { registerTypeDefs, registeredTypeDefs } = await import('./types')
+
+    const customTypeDef = { kind: 'Document' } as any
+    registerTypeDefs(customTypeDef)
+
+    const defs = registeredTypeDefs()
+    expect(defs).toHaveLength(2)
+    expect(defs[1]).toBe(customTypeDef)
+  })
+
+  it('should accumulate multiple type def registrations', async () => {
+    const { registerTypeDefs, registeredTypeDefs } = await import('./types')
+
+    registerTypeDefs({ kind: 'Doc1' } as any)
+    registerTypeDefs({ kind: 'Doc2' } as any)
+
+    expect(registeredTypeDefs()).toHaveLength(3)
+  })
+})

--- a/packages/kit/src/ioc.test.ts
+++ b/packages/kit/src/ioc.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useContainer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('should return a Container instance', async () => {
+    const { useContainer } = await import('./ioc')
+    const container = useContainer()
+    expect(container).toBeDefined()
+    expect(typeof container.bind).toBe('function')
+    expect(typeof container.make).toBe('function')
+  })
+
+  it('should return the same instance on repeated calls (singleton)', async () => {
+    const { useContainer } = await import('./ioc')
+    const first = useContainer()
+    const second = useContainer()
+    expect(first).toBe(second)
+  })
+
+  it('should re-export Container class from @adonisjs/fold', async () => {
+    const { Container } = await import('./ioc')
+    expect(Container).toBeDefined()
+    expect(typeof Container).toBe('function')
+  })
+})

--- a/packages/kit/src/logger.test.ts
+++ b/packages/kit/src/logger.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('consola', () => {
+  const mockLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn(),
+    create: vi.fn(),
+  }
+  // withTag returns a new mock logger
+  mockLogger.withTag.mockReturnValue({ ...mockLogger, _tag: true })
+  // create returns an object with withTag
+  const createdLogger = {
+    withTag: vi.fn().mockReturnValue({ _tagged: true }),
+  }
+  mockLogger.create.mockReturnValue(createdLogger)
+
+  return { consola: mockLogger }
+})
+
+describe('useLogger', () => {
+  it('should return the base consola logger when called without arguments', async () => {
+    const { useLogger, logger } = await import('./logger')
+    const result = useLogger()
+    expect(result).toBe(logger)
+  })
+
+  it('should return a tagged logger when called with a tag', async () => {
+    const { useLogger } = await import('./logger')
+    const result = useLogger('my-module')
+    expect(result).toHaveProperty('_tagged', true)
+  })
+
+  it('should pass options to create() when tag is provided', async () => {
+    const { useLogger, logger } = await import('./logger')
+    const opts = { level: 3 }
+    useLogger('tag', opts as any)
+    expect(logger.create).toHaveBeenCalledWith(opts)
+  })
+})

--- a/packages/kit/src/utils.test.ts
+++ b/packages/kit/src/utils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { distDirURL, filterInPlace, MODE_RE, toArray } from './utils'
+
+describe('toArray', () => {
+  it('should wrap a single value in an array', () => {
+    expect(toArray('hello')).toEqual(['hello'])
+  })
+
+  it('should return an array as-is', () => {
+    const arr = [1, 2, 3]
+    expect(toArray(arr)).toBe(arr)
+  })
+
+  it('should return an empty array as-is', () => {
+    const arr: string[] = []
+    expect(toArray(arr)).toBe(arr)
+    expect(toArray(arr)).toEqual([])
+  })
+
+  it('should wrap falsy values', () => {
+    expect(toArray(0)).toEqual([0])
+    expect(toArray(null)).toEqual([null])
+    expect(toArray(false)).toEqual([false])
+  })
+})
+
+describe('filterInPlace', () => {
+  it('should keep items matching the predicate', () => {
+    const arr = [1, 2, 3, 4, 5]
+    filterInPlace(arr, n => n > 2)
+    expect(arr).toEqual([3, 4, 5])
+  })
+
+  it('should remove items not matching the predicate', () => {
+    const arr = ['a', 'bb', 'ccc', 'd']
+    filterInPlace(arr, s => s.length === 1)
+    expect(arr).toEqual(['a', 'd'])
+  })
+
+  it('should return the same array reference (mutate in place)', () => {
+    const arr = [1, 2, 3]
+    const result = filterInPlace(arr, n => n !== 2)
+    expect(result).toBe(arr)
+  })
+
+  it('should handle an empty array', () => {
+    const arr: number[] = []
+    filterInPlace(arr, () => true)
+    expect(arr).toEqual([])
+  })
+
+  it('should pass index and array to predicate', () => {
+    const indices: number[] = []
+    const arr = [10, 20, 30]
+    filterInPlace(arr, (_item, index, a) => {
+      indices.push(index)
+      expect(a).toBe(arr)
+      return true
+    })
+    // Iterates from end to start
+    expect(indices).toEqual([2, 1, 0])
+  })
+})
+
+describe('mode regex (MODE_RE)', () => {
+  it('should match .server.ts', () => {
+    expect(MODE_RE.test('plugin.server.ts')).toBe(true)
+  })
+
+  it('should match .client.ts', () => {
+    expect(MODE_RE.test('plugin.client.ts')).toBe(true)
+  })
+
+  it('should match .server with extra extensions', () => {
+    expect(MODE_RE.test('plugin.server.dev.ts')).toBe(true)
+  })
+
+  it('should not match regular filenames', () => {
+    expect(MODE_RE.test('plugin.ts')).toBe(false)
+    expect(MODE_RE.test('server.ts')).toBe(false)
+    expect(MODE_RE.test('plugin.test.ts')).toBe(false)
+  })
+})
+
+describe('distDirURL', () => {
+  it('should be a URL instance', () => {
+    expect(distDirURL).toBeInstanceOf(URL)
+  })
+})


### PR DESCRIPTION
## Summary

- Add 6 new test files covering previously zero-coverage `@czo/kit` modules: `utils.ts`, `ioc.ts`, `logger.ts`, `db/manager.ts`, `graphql/resolvers.ts`, `graphql/types.ts`
- Enhance `db/repository.test.ts` with `#toDatabaseError` PG 23505 branch tests and pagination edge cases
- All 6 targeted files now at **100% statement coverage**; 237 total tests passing

## Details

| New Test File | Source | Coverage |
|---|---|---|
| `src/utils.test.ts` | `utils.ts` | 100% (14 tests) |
| `src/ioc.test.ts` | `ioc.ts` | 100% (3 tests) |
| `src/logger.test.ts` | `logger.ts` | 100% (3 tests) |
| `src/db/manager.test.ts` | `db/manager.ts` | 100% (6 tests) |
| `src/graphql/resolvers.test.ts` | `graphql/resolvers.ts` | 100% (3 tests) |
| `src/graphql/types.test.ts` | `graphql/types.ts` | 100% (3 tests) |
| `src/db/repository.test.ts` (enhanced) | `db/repository.ts` | 85.61% (+7 tests) |

Overall kit coverage: 75.35% → remaining gap is from Nitro-dependent files deferred to #40.

Closes #39

## Test plan

- [x] `pnpm --filter @czo/kit test -- --run` — 237 tests pass
- [x] `pnpm --filter @czo/kit lint` — zero warnings
- [x] `pnpm --filter @czo/kit build` — clean build
- [ ] Verify CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)