### PR TITLE
feat(auth): session management with actor context (#56)

### DIFF
--- a/packages/modules/auth/migrations/0001_add_session_context.sql
+++ b/packages/modules/auth/migrations/0001_add_session_context.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "session" ADD COLUMN "actor_type" text NOT NULL DEFAULT 'customer';
+ALTER TABLE "session" ADD COLUMN "auth_method" text NOT NULL DEFAULT 'email';
+ALTER TABLE "session" ADD COLUMN "organization_id" text;

--- a/packages/modules/auth/src/database/schema.test.ts
+++ b/packages/modules/auth/src/database/schema.test.ts
@@ -46,6 +46,32 @@ describe('auth database schema', () => {
       expect(columnNames).toContain('ip_address')
       expect(columnNames).toContain('user_agent')
       expect(columnNames).toContain('user_id')
+      expect(columnNames).toContain('actor_type')
+      expect(columnNames).toContain('auth_method')
+      expect(columnNames).toContain('organization_id')
+    })
+
+    it('should have actor_type with default "customer"', () => {
+      const config = getTableConfig(schema.session)
+      const col = config.columns.find(c => c.name === 'actor_type')
+      expect(col).toBeDefined()
+      expect(col!.notNull).toBe(true)
+      expect(col!.default).toBe('customer')
+    })
+
+    it('should have auth_method with default "email"', () => {
+      const config = getTableConfig(schema.session)
+      const col = config.columns.find(c => c.name === 'auth_method')
+      expect(col).toBeDefined()
+      expect(col!.notNull).toBe(true)
+      expect(col!.default).toBe('email')
+    })
+
+    it('should have organization_id as nullable', () => {
+      const config = getTableConfig(schema.session)
+      const col = config.columns.find(c => c.name === 'organization_id')
+      expect(col).toBeDefined()
+      expect(col!.notNull).toBe(false)
     })
 
     it('should have token as unique', () => {

--- a/packages/modules/auth/src/database/schema.ts
+++ b/packages/modules/auth/src/database/schema.ts
@@ -19,6 +19,9 @@ export const session = pgTable('session', {
   ipAddress: text('ip_address'),
   userAgent: text('user_agent'),
   userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
+  actorType: text('actor_type').notNull().default('customer'),
+  authMethod: text('auth_method').notNull().default('email'),
+  organizationId: text('organization_id'),
 })
 
 export const account = pgTable('account', {

--- a/packages/modules/auth/src/routes/auth/[actor]/sign-out.post.ts
+++ b/packages/modules/auth/src/routes/auth/[actor]/sign-out.post.ts
@@ -1,0 +1,50 @@
+import type { Auth } from '../../../config/auth.config'
+import type { JwtBlocklist } from '../../../services/jwt-blocklist'
+import type { Actor } from './[...all]'
+import { Buffer } from 'node:buffer'
+import { defineHandler, getRouterParam, HTTPError } from 'nitro/h3'
+import { JWT_EXPIRATION_SECONDS } from '../../../config/auth.config'
+import { VALID_ACTORS } from './[...all]'
+
+export default defineHandler(async (event) => {
+  const auth = (event.context as Record<string, unknown>).auth as Auth | undefined
+  const blocklist = (event.context as Record<string, unknown>).blocklist as JwtBlocklist | undefined
+
+  if (!auth) {
+    throw new HTTPError({ status: 500, statusText: 'Auth not initialized' })
+  }
+
+  const actor = getRouterParam(event, 'actor')
+
+  if (!actor || !VALID_ACTORS.includes(actor as Actor)) {
+    throw new HTTPError({ status: 400, statusText: `Invalid actor: ${actor}. Must be one of: ${VALID_ACTORS.join(', ')}` })
+  }
+
+  // Blocklist the current JWT (best effort) before sign-out destroys the session
+  if (blocklist) {
+    try {
+      const tokenResponse = await auth.api.getToken({
+        headers: event.req.headers,
+      })
+      if (tokenResponse?.token) {
+        const [, payload] = tokenResponse.token.split('.')
+        if (payload) {
+          const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString())
+          if (decoded.jti) {
+            await blocklist.add(decoded.jti, JWT_EXPIRATION_SECONDS)
+          }
+        }
+      }
+    }
+    catch {
+      // Best effort — JWT expires naturally in 15 minutes
+    }
+  }
+
+  // Rewrite URL: strip /{actor}/ segment so better-auth sees /api/auth/sign-out
+  const url = new URL(event.req.url)
+  url.pathname = url.pathname.replace(`/auth/${actor}/`, '/auth/')
+  const rewrittenReq = new Request(url, event.req)
+
+  return auth.handler(rewrittenReq)
+})

--- a/packages/modules/auth/src/routes/auth/[actor]/sign-out.test.ts
+++ b/packages/modules/auth/src/routes/auth/[actor]/sign-out.test.ts
@@ -1,0 +1,195 @@
+import { Buffer } from 'node:buffer'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetRouterParam = vi.hoisted(() => vi.fn())
+
+const MockHTTPError = vi.hoisted(() =>
+  class extends Error {
+    status: number
+    statusText: string
+    constructor(opts: { status: number, statusText: string }) {
+      super(opts.statusText)
+      this.status = opts.status
+      this.statusText = opts.statusText
+    }
+  },
+)
+
+vi.mock('nitro/h3', () => ({
+  defineHandler: (fn: (event: unknown) => Promise<unknown>) => fn,
+  getRouterParam: mockGetRouterParam,
+  HTTPError: MockHTTPError,
+}))
+
+vi.mock('../../../config/auth.config', () => ({
+  JWT_EXPIRATION_SECONDS: 900,
+}))
+
+vi.mock('./[...all]', () => ({
+  VALID_ACTORS: ['customer', 'admin'],
+}))
+
+// eslint-disable-next-line import/first
+import handler from './sign-out.post'
+
+describe('sign-out route', () => {
+  const mockGetToken = vi.fn()
+  const mockHandler = vi.fn()
+  const mockBlocklistAdd = vi.fn()
+
+  function createEvent(overrides?: {
+    auth?: unknown
+    blocklist?: unknown
+    actor?: string
+  }) {
+    const actor = overrides?.actor ?? 'customer'
+    const req = new Request(`http://localhost/api/auth/${actor}/sign-out`, {
+      method: 'POST',
+    })
+    return {
+      req,
+      context: {
+        auth: overrides?.auth !== undefined
+          ? overrides.auth
+          : {
+              handler: mockHandler,
+              api: { getToken: mockGetToken },
+            },
+        ...(overrides?.blocklist !== undefined
+          ? { blocklist: overrides.blocklist }
+          : {}),
+      },
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should throw 500 if auth is not in context', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    const event = createEvent({ auth: null })
+
+    const err = await (handler as (event: unknown) => Promise<unknown>)(event)
+      .catch((e: unknown) => e) as InstanceType<typeof MockHTTPError>
+
+    expect(err).toBeInstanceOf(MockHTTPError)
+    expect(err.status).toBe(500)
+  })
+
+  it('should throw 400 for invalid actor', async () => {
+    mockGetRouterParam.mockReturnValue('hacker')
+    const event = createEvent({ actor: 'hacker' })
+
+    const err = await (handler as (event: unknown) => Promise<unknown>)(event)
+      .catch((e: unknown) => e) as InstanceType<typeof MockHTTPError>
+
+    expect(err).toBeInstanceOf(MockHTTPError)
+    expect(err.status).toBe(400)
+    expect(err.statusText).toContain('Invalid actor')
+  })
+
+  it('should call auth.handler with rewritten URL', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+    const event = createEvent()
+
+    await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(mockHandler).toHaveBeenCalled()
+    const calledReq = mockHandler.mock.calls[0]![0] as Request
+    const url = new URL(calledReq.url)
+    expect(url.pathname).toBe('/api/auth/sign-out')
+  })
+
+  it('should blocklist JWT jti when blocklist is available', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    // Create a fake JWT with jti claim
+    const payload = Buffer.from(JSON.stringify({ jti: 'jwt-123', sub: 'u1' })).toString('base64url')
+    const fakeJwt = `eyJhbGciOiJFUzI1NiJ9.${payload}.signature`
+    mockGetToken.mockResolvedValue({ token: fakeJwt })
+
+    const blocklist = { add: mockBlocklistAdd, isBlocked: vi.fn() }
+    const event = createEvent({ blocklist })
+
+    await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(mockBlocklistAdd).toHaveBeenCalledWith('jwt-123', 900)
+  })
+
+  it('should not fail when blocklist is not available', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+    const event = createEvent()
+
+    const result = await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(result).toBeInstanceOf(Response)
+    expect(mockBlocklistAdd).not.toHaveBeenCalled()
+  })
+
+  it('should not fail when getToken throws', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+    mockGetToken.mockRejectedValue(new Error('No session'))
+
+    const blocklist = { add: mockBlocklistAdd, isBlocked: vi.fn() }
+    const event = createEvent({ blocklist })
+
+    const result = await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(result).toBeInstanceOf(Response)
+    expect(mockBlocklistAdd).not.toHaveBeenCalled()
+  })
+
+  it('should not fail when getToken returns no token', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+    mockGetToken.mockResolvedValue(null)
+
+    const blocklist = { add: mockBlocklistAdd, isBlocked: vi.fn() }
+    const event = createEvent({ blocklist })
+
+    const result = await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(result).toBeInstanceOf(Response)
+    expect(mockBlocklistAdd).not.toHaveBeenCalled()
+  })
+
+  it('should not fail when JWT has no jti claim', async () => {
+    mockGetRouterParam.mockReturnValue('customer')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+
+    const payload = Buffer.from(JSON.stringify({ sub: 'u1' })).toString('base64url')
+    const fakeJwt = `eyJhbGciOiJFUzI1NiJ9.${payload}.signature`
+    mockGetToken.mockResolvedValue({ token: fakeJwt })
+
+    const blocklist = { add: mockBlocklistAdd, isBlocked: vi.fn() }
+    const event = createEvent({ blocklist })
+
+    const result = await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    expect(result).toBeInstanceOf(Response)
+    expect(mockBlocklistAdd).not.toHaveBeenCalled()
+  })
+
+  it('should strip admin actor from URL when signing out as admin', async () => {
+    mockGetRouterParam.mockReturnValue('admin')
+    mockHandler.mockResolvedValue(new Response('{}', { status: 200 }))
+    const req = new Request('http://localhost/api/auth/admin/sign-out', { method: 'POST' })
+    const event = {
+      req,
+      context: {
+        auth: { handler: mockHandler, api: { getToken: mockGetToken } },
+      },
+    }
+
+    await (handler as (event: unknown) => Promise<unknown>)(event)
+
+    const calledReq = mockHandler.mock.calls[0]![0] as Request
+    const url = new URL(calledReq.url)
+    expect(url.pathname).toBe('/api/auth/sign-out')
+  })
+})

--- a/packages/modules/auth/src/services/session-context.test.ts
+++ b/packages/modules/auth/src/services/session-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { getSessionContext, runWithSessionContext } from './session-context'
+
+describe('session context', () => {
+  it('should return undefined when called outside runWithSessionContext', () => {
+    expect(getSessionContext()).toBeUndefined()
+  })
+
+  it('should return the context data inside runWithSessionContext', () => {
+    const data = { actorType: 'customer', authMethod: 'email' }
+    runWithSessionContext(data, () => {
+      expect(getSessionContext()).toEqual(data)
+    })
+  })
+
+  it('should propagate organizationId when provided', () => {
+    const data = { actorType: 'admin', authMethod: 'email', organizationId: 'org-123' }
+    runWithSessionContext(data, () => {
+      const ctx = getSessionContext()
+      expect(ctx?.organizationId).toBe('org-123')
+    })
+  })
+
+  it('should support nested contexts with inner overriding outer', () => {
+    const outer = { actorType: 'customer', authMethod: 'email' }
+    const inner = { actorType: 'admin', authMethod: 'oauth' }
+
+    runWithSessionContext(outer, () => {
+      expect(getSessionContext()?.actorType).toBe('customer')
+
+      runWithSessionContext(inner, () => {
+        expect(getSessionContext()?.actorType).toBe('admin')
+        expect(getSessionContext()?.authMethod).toBe('oauth')
+      })
+
+      expect(getSessionContext()?.actorType).toBe('customer')
+    })
+  })
+
+  it('should return undefined after runWithSessionContext completes', () => {
+    runWithSessionContext({ actorType: 'customer', authMethod: 'email' }, () => {
+      // context is set
+    })
+    expect(getSessionContext()).toBeUndefined()
+  })
+
+  it('should work with async functions', async () => {
+    const data = { actorType: 'admin', authMethod: 'email', organizationId: 'org-1' }
+    const result = await runWithSessionContext(data, async () => {
+      await new Promise(resolve => setTimeout(resolve, 1))
+      return getSessionContext()
+    })
+    expect(result).toEqual(data)
+  })
+})

--- a/packages/modules/auth/src/services/session-context.ts
+++ b/packages/modules/auth/src/services/session-context.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+export interface SessionContextData {
+  actorType: string
+  authMethod: string
+  organizationId?: string
+}
+
+const storage = new AsyncLocalStorage<SessionContextData>()
+
+export function runWithSessionContext<T>(data: SessionContextData, fn: () => T): T {
+  return storage.run(data, fn)
+}
+
+export function getSessionContext(): SessionContextData | undefined {
+  return storage.getStore()
+}


### PR DESCRIPTION
## Summary

- **Session actor context**: Sessions now carry `actorType`, `authMethod`, and `organizationId` — injected server-side via AsyncLocalStorage + better-auth `databaseHooks`
- **Sign-out with JWT blocklisting**: Dedicated `POST /api/auth/{actor}/sign-out` route that blocklists the JWT `jti` in Redis before deleting the session
- **Session TTL & refresh**: 7-day expiry with automatic refresh after 1 day (`updateAge: 86400`)
- **Cookie transport**: `czo` prefix, `httpOnly`, `sameSite: lax`, auto-secure for HTTPS
- **Plugin context injection**: `blocklist`, `rotation`, and `db` now injected into `event.context` (fixes latent bug where `refresh.post.ts` expected these but they weren't set)
- **JWT claims refinement**: `act`, `org`, `method` now read from session fields instead of `activeOrganizationId`
- **Migration**: `0001_add_session_context.sql` adds 3 columns to session table

### New files
| File | Purpose |
|------|---------|
| `src/services/session-context.ts` | AsyncLocalStorage for actor propagation |
| `src/routes/auth/[actor]/sign-out.post.ts` | Sign-out with JWT blocklisting |
| `migrations/0001_add_session_context.sql` | Schema migration |

### Deferred to #57
- GraphQL `mySessions` query, `revokeSession` / `revokeAllOtherSessions` mutations

## Test plan

- [x] 172 tests passing (14 test files)
- [x] 0 lint warnings (`eslint --max-warnings 0`)
- [x] Build succeeds (`unbuild`)
- [ ] Integration test: sign-in creates session with correct `actorType`
- [ ] Integration test: sign-out blocklists JWT `jti`
- [ ] Verify cookie `czo.session_token` set on sign-in response

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)