### PR TITLE
feat(auth): implement organizations with types and GraphQL tooling (#59)

### DIFF
--- a/apps/mazo/api/graphql.ts
+++ b/apps/mazo/api/graphql.ts
@@ -1,12 +1,14 @@
 import { NoSchemaIntrospectionCustomRule } from 'graphql'
-import { createYoga, createSchema } from 'graphql-yoga'
+import { createYoga } from 'graphql-yoga'
 import { defineHandler } from 'nitro/h3'
 import { mergeTypeDefs, mergeResolvers } from '@graphql-tools/merge'
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { registeredTypeDefs, registeredResolvers } from '@czo/kit/graphql'
 import { validateGraphQLAuth, isIntrospectionQuery } from '@czo/auth/graphql-auth'
 
 const isDev = process.env.NODE_ENV !== 'production'
 
-const schema = createSchema({
+const schema = makeExecutableSchema({
   typeDefs: mergeTypeDefs(registeredTypeDefs()),
   resolvers: mergeResolvers(registeredResolvers()),
 })
@@ -45,5 +47,9 @@ export default defineHandler(async (event) => {
     cookiePrefix: 'czo',
   })
 
-  return yoga.fetch(event.req, { auth: authContext })
+  return yoga.fetch(event.req, {
+    auth: authContext,
+    authInstance: event.context.auth,
+    request: event.req,
+  })
 })

--- a/apps/mazo/package.json
+++ b/apps/mazo/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@graphql-tools/merge": "catalog:common",
+    "@graphql-tools/schema": "catalog:",
     "graphql": "catalog:common",
     "graphql-yoga": "catalog:common",
     "kysely": "catalog:common"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -127,6 +127,7 @@
     "consola": "catalog:common",
     "drizzle-orm": "catalog:common",
     "exsolve": "catalog:common",
+    "graphql-scalars": "catalog:common",
     "hookable": "catalog:dev",
     "jiti": "catalog:common",
     "kysely": "catalog:common",

--- a/packages/kit/src/graphql/index.ts
+++ b/packages/kit/src/graphql/index.ts
@@ -1,2 +1,3 @@
 export * from './resolvers'
+export * from './scalars'
 export * from './types'

--- a/packages/kit/src/graphql/resolvers.test.ts
+++ b/packages/kit/src/graphql/resolvers.test.ts
@@ -5,28 +5,35 @@ describe('graphql/resolvers', () => {
     vi.resetModules()
   })
 
-  it('should return an empty array by default', async () => {
+  it('should include scalar resolvers by default', async () => {
     const { registeredResolvers } = await import('./resolvers')
-    expect(registeredResolvers()).toEqual([])
+    const resolvers = registeredResolvers()
+
+    expect(resolvers.length).toBeGreaterThanOrEqual(1)
+    const scalars = resolvers[0] as Record<string, unknown>
+    expect(scalars.DateTime).toBeDefined()
+    expect(scalars.EmailAddress).toBeDefined()
   })
 
   it('should accumulate resolvers via registerResolvers()', async () => {
     const { registerResolvers, registeredResolvers } = await import('./resolvers')
+    const before = registeredResolvers().length
 
     const resolver1 = { Query: { hello: () => 'world' } }
     registerResolvers(resolver1)
 
-    expect(registeredResolvers()).toHaveLength(1)
-    expect(registeredResolvers()[0]).toBe(resolver1)
+    expect(registeredResolvers()).toHaveLength(before + 1)
+    expect(registeredResolvers()[registeredResolvers().length - 1]).toBe(resolver1)
   })
 
   it('should accumulate multiple registrations', async () => {
     const { registerResolvers, registeredResolvers } = await import('./resolvers')
+    const before = registeredResolvers().length
 
     registerResolvers({ Query: { a: () => 1 } })
     registerResolvers({ Mutation: { b: () => 2 } })
     registerResolvers({ Query: { c: () => 3 } })
 
-    expect(registeredResolvers()).toHaveLength(3)
+    expect(registeredResolvers()).toHaveLength(before + 3)
   })
 })

--- a/packages/kit/src/graphql/resolvers.ts
+++ b/packages/kit/src/graphql/resolvers.ts
@@ -1,8 +1,10 @@
+import { scalarResolvers } from './scalars'
+
 type Resolver<T> = {
   [K in keyof T]: Resolver<T[K]>
 }
 
-const resolvers: Array<Resolver<unknown>> = []
+const resolvers: Array<Resolver<unknown>> = [scalarResolvers as Resolver<unknown>]
 
 export function registerResolvers<T extends Resolver<unknown>>(resolver: T) {
   resolvers.push(resolver)

--- a/packages/kit/src/graphql/scalars.ts
+++ b/packages/kit/src/graphql/scalars.ts
@@ -1,0 +1,13 @@
+import {
+  DateTimeResolver,
+  DateTimeTypeDefinition,
+  EmailAddressResolver,
+  EmailAddressTypeDefinition,
+} from 'graphql-scalars'
+
+export const scalarTypeDefs = [DateTimeTypeDefinition, EmailAddressTypeDefinition]
+
+export const scalarResolvers = {
+  DateTime: DateTimeResolver,
+  EmailAddress: EmailAddressResolver,
+}

--- a/packages/kit/src/graphql/types.test.ts
+++ b/packages/kit/src/graphql/types.test.ts
@@ -5,32 +5,45 @@ describe('graphql/types', () => {
     vi.resetModules()
   })
 
-  it('should include default Query and Mutation type defs', async () => {
+  it('should include default Query/Mutation type defs and scalar type defs', async () => {
     const { registeredTypeDefs } = await import('./types')
     const defs = registeredTypeDefs()
 
-    expect(defs).toHaveLength(1)
+    // Base Query/Mutation + DateTime + EmailAddress scalar defs
+    expect(defs.length).toBeGreaterThanOrEqual(3)
     expect(defs[0]).toContain('type Query')
     expect(defs[0]).toContain('type Mutation')
   })
 
   it('should append type defs via registerTypeDefs()', async () => {
     const { registerTypeDefs, registeredTypeDefs } = await import('./types')
+    const before = registeredTypeDefs().length
 
     const customTypeDef = { kind: 'Document' } as any
     registerTypeDefs(customTypeDef)
 
     const defs = registeredTypeDefs()
-    expect(defs).toHaveLength(2)
-    expect(defs[1]).toBe(customTypeDef)
+    expect(defs).toHaveLength(before + 1)
+    expect(defs[defs.length - 1]).toBe(customTypeDef)
   })
 
   it('should accumulate multiple type def registrations', async () => {
     const { registerTypeDefs, registeredTypeDefs } = await import('./types')
+    const before = registeredTypeDefs().length
 
     registerTypeDefs({ kind: 'Doc1' } as any)
     registerTypeDefs({ kind: 'Doc2' } as any)
 
-    expect(registeredTypeDefs()).toHaveLength(3)
+    expect(registeredTypeDefs()).toHaveLength(before + 2)
+  })
+
+  it('should accept a raw SDL string', async () => {
+    const { registerTypeDefs, registeredTypeDefs } = await import('./types')
+
+    const sdl = 'type Foo { bar: String }'
+    registerTypeDefs(sdl)
+
+    const defs = registeredTypeDefs()
+    expect(defs[defs.length - 1]).toBe(sdl)
   })
 })

--- a/packages/kit/src/graphql/types.ts
+++ b/packages/kit/src/graphql/types.ts
@@ -1,4 +1,5 @@
 import type { DocumentNode } from 'graphql'
+import { scalarTypeDefs } from './scalars'
 
 const typeDefs: Array<DocumentNode | string> = [
   `
@@ -9,9 +10,10 @@ const typeDefs: Array<DocumentNode | string> = [
       _empty: String
     }
   `,
+  ...scalarTypeDefs,
 ]
 
-export function registerTypeDefs(typeDef: DocumentNode) {
+export function registerTypeDefs(typeDef: DocumentNode | string) {
   typeDefs.push(typeDef)
 }
 

--- a/packages/modules/auth/build.config.ts
+++ b/packages/modules/auth/build.config.ts
@@ -45,6 +45,11 @@ export default defineBuildConfig({
       outDir: 'dist/services',
       ...dirImport,
     },
+    {
+      input: 'src/graphql/',
+      outDir: 'dist/graphql',
+      ...dirImport,
+    },
   ],
   externals: [
     'nitropack',
@@ -64,6 +69,9 @@ export default defineBuildConfig({
     'drizzle-orm/pg-core',
     'ioredis',
     'better-auth/crypto',
+    'better-auth/plugins/access',
+    '@czo/kit/graphql',
     'graphql',
+    'graphql-scalars',
   ],
 })

--- a/packages/modules/auth/codegen.ts
+++ b/packages/modules/auth/codegen.ts
@@ -1,0 +1,20 @@
+import type { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: 'src/graphql/schema/*.graphql',
+  generates: {
+    'src/graphql/__generated__/resolver-types.ts': {
+      plugins: ['typescript', 'typescript-resolvers'],
+      config: {
+        contextType: '../../types#GraphQLContext',
+        useIndexSignature: true,
+        scalars: {
+          DateTime: 'Date | string',
+          EmailAddress: 'string',
+        },
+      },
+    },
+  },
+}
+
+export default config

--- a/packages/modules/auth/eslint.config.js
+++ b/packages/modules/auth/eslint.config.js
@@ -1,3 +1,5 @@
 import { config } from '@workspace/eslint-config/base'
 
-export default config
+export default config.append({
+  ignores: ['src/graphql/__generated__/**'],
+})

--- a/packages/modules/auth/migrations/0003_add_organizations.sql
+++ b/packages/modules/auth/migrations/0003_add_organizations.sql
@@ -1,0 +1,55 @@
+ALTER TABLE "sessions" ADD COLUMN "active_organization_id" text;--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "organizations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"logo" text,
+	"metadata" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp,
+	CONSTRAINT "organizations_slug_unique" UNIQUE("slug")
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "members" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text DEFAULT 'member' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "invitations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"email" text NOT NULL,
+	"role" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"inviter_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "members" ADD CONSTRAINT "members_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "members" ADD CONSTRAINT "members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "invitations" ADD CONSTRAINT "invitations_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+
+DO $$ BEGIN
+ ALTER TABLE "invitations" ADD CONSTRAINT "invitations_inviter_id_users_id_fk" FOREIGN KEY ("inviter_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/modules/auth/migrations/0004_add_organization_type.sql
+++ b/packages/modules/auth/migrations/0004_add_organization_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ADD COLUMN "type" text;

--- a/packages/modules/auth/migrations/meta/_journal.json
+++ b/packages/modules/auth/migrations/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1770861242537,
       "tag": "0002_rename_tables_plural",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1770947642537,
+      "tag": "0003_add_organizations",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1771034042537,
+      "tag": "0004_add_organization_type",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/modules/auth/package.json
+++ b/packages/modules/auth/package.json
@@ -38,6 +38,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "graphql:generate": "graphql-codegen --config codegen.ts",
     "migrate:generate": "drizzle-kit generate",
     "migrate:latest": "drizzle-kit migrate",
     "migrate:status": "drizzle-kit check"
@@ -50,6 +51,9 @@
     "ioredis": "catalog:common"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "catalog:dev",
+    "@graphql-codegen/typescript": "catalog:dev",
+    "@graphql-codegen/typescript-resolvers": "catalog:dev",
     "@vitest/coverage-v8": "catalog:testing",
     "@workspace/eslint-config": "workspace:*",
     "@workspace/typescript-config": "workspace:*",

--- a/packages/modules/auth/src/database/schema.test.ts
+++ b/packages/modules/auth/src/database/schema.test.ts
@@ -146,6 +146,39 @@ describe('auth database schema', () => {
     })
   })
 
+  describe('organizations table', () => {
+    it('should be named "organizations"', () => {
+      expect(getTableName(schema.organizations)).toBe('organizations')
+    })
+
+    it('should have required columns', () => {
+      const config = getTableConfig(schema.organizations)
+      const columnNames = config.columns.map(c => c.name)
+
+      expect(columnNames).toContain('id')
+      expect(columnNames).toContain('name')
+      expect(columnNames).toContain('slug')
+      expect(columnNames).toContain('logo')
+      expect(columnNames).toContain('metadata')
+      expect(columnNames).toContain('type')
+      expect(columnNames).toContain('created_at')
+      expect(columnNames).toContain('updated_at')
+    })
+
+    it('should have type column as nullable', () => {
+      const config = getTableConfig(schema.organizations)
+      const col = config.columns.find(c => c.name === 'type')
+      expect(col).toBeDefined()
+      expect(col!.notNull).toBe(false)
+    })
+
+    it('should have slug as unique', () => {
+      const config = getTableConfig(schema.organizations)
+      const slugCol = config.columns.find(c => c.name === 'slug')
+      expect(slugCol?.isUnique).toBe(true)
+    })
+  })
+
   it('should export all 5 tables', () => {
     expect(schema.users).toBeDefined()
     expect(schema.sessions).toBeDefined()

--- a/packages/modules/auth/src/database/schema.ts
+++ b/packages/modules/auth/src/database/schema.ts
@@ -22,6 +22,7 @@ export const sessions = pgTable('sessions', {
   actorType: text('actor_type').notNull().default('customer'),
   authMethod: text('auth_method').notNull().default('email'),
   organizationId: text('organization_id'),
+  activeOrganizationId: text('active_organization_id'),
 })
 
 export const accounts = pgTable('accounts', {
@@ -53,5 +54,35 @@ export const jwks = pgTable('jwks', {
   id: text('id').primaryKey(),
   publicKey: text('public_key').notNull(),
   privateKey: text('private_key').notNull(),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+})
+
+export const organizations = pgTable('organizations', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  slug: text('slug').notNull().unique(),
+  logo: text('logo'),
+  metadata: text('metadata'),
+  type: text('type'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+  updatedAt: timestamp('updated_at'),
+})
+
+export const members = pgTable('members', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+  role: text('role').notNull().default('member'),
+  createdAt: timestamp('created_at').notNull().defaultNow(),
+})
+
+export const invitations = pgTable('invitations', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull().references(() => organizations.id, { onDelete: 'cascade' }),
+  email: text('email').notNull(),
+  role: text('role').notNull(),
+  status: text('status').notNull().default('pending'),
+  expiresAt: timestamp('expires_at').notNull(),
+  inviterId: text('inviter_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   createdAt: timestamp('created_at').notNull().defaultNow(),
 })

--- a/packages/modules/auth/src/events/auth-events.test.ts
+++ b/packages/modules/auth/src/events/auth-events.test.ts
@@ -103,6 +103,66 @@ describe('authEventsService', () => {
     })
   })
 
+  describe('orgCreated', () => {
+    it('should publish auth.org.created event with correct payload', async () => {
+      const payload = { orgId: 'org1', ownerId: 'u1', name: 'My Org', type: 'merchant' as string | null }
+
+      await service.orgCreated(payload)
+
+      expect(mockCreateDomainEvent).toHaveBeenCalledWith({
+        type: AUTH_EVENTS.ORG_CREATED,
+        payload,
+        metadata: { source: 'auth' },
+      })
+      expect(mockPublish).toHaveBeenCalled()
+    })
+  })
+
+  describe('orgMemberAdded', () => {
+    it('should publish auth.org.member.added event with correct payload', async () => {
+      const payload = { orgId: 'org1', userId: 'u2', role: 'member' }
+
+      await service.orgMemberAdded(payload)
+
+      expect(mockCreateDomainEvent).toHaveBeenCalledWith({
+        type: AUTH_EVENTS.ORG_MEMBER_ADDED,
+        payload,
+        metadata: { source: 'auth' },
+      })
+      expect(mockPublish).toHaveBeenCalled()
+    })
+  })
+
+  describe('orgMemberRemoved', () => {
+    it('should publish auth.org.member.removed event with correct payload', async () => {
+      const payload = { orgId: 'org1', userId: 'u2' }
+
+      await service.orgMemberRemoved(payload)
+
+      expect(mockCreateDomainEvent).toHaveBeenCalledWith({
+        type: AUTH_EVENTS.ORG_MEMBER_REMOVED,
+        payload,
+        metadata: { source: 'auth' },
+      })
+      expect(mockPublish).toHaveBeenCalled()
+    })
+  })
+
+  describe('orgRoleChanged', () => {
+    it('should publish auth.org.role.changed event with correct payload', async () => {
+      const payload = { orgId: 'org1', userId: 'u2', previousRole: 'member', newRole: 'admin' }
+
+      await service.orgRoleChanged(payload)
+
+      expect(mockCreateDomainEvent).toHaveBeenCalledWith({
+        type: AUTH_EVENTS.ORG_ROLE_CHANGED,
+        payload,
+        metadata: { source: 'auth' },
+      })
+      expect(mockPublish).toHaveBeenCalled()
+    })
+  })
+
   describe('safePublish (fire-and-forget)', () => {
     it('should catch and log errors without throwing', async () => {
       mockPublish.mockRejectedValueOnce(new Error('Bus offline'))

--- a/packages/modules/auth/src/events/auth-events.ts
+++ b/packages/modules/auth/src/events/auth-events.ts
@@ -1,5 +1,9 @@
 import type { EventBus } from '@czo/kit/event-bus'
 import type {
+  AuthOrgCreatedPayload,
+  AuthOrgMemberAddedPayload,
+  AuthOrgMemberRemovedPayload,
+  AuthOrgRoleChangedPayload,
   AuthSessionCreatedPayload,
   AuthSessionRevokedPayload,
   AuthUserRegisteredPayload,
@@ -56,5 +60,21 @@ export class AuthEventsService {
 
   async sessionRevoked(payload: AuthSessionRevokedPayload): Promise<void> {
     await this.safePublish(AUTH_EVENTS.SESSION_REVOKED, payload)
+  }
+
+  async orgCreated(payload: AuthOrgCreatedPayload): Promise<void> {
+    await this.safePublish(AUTH_EVENTS.ORG_CREATED, payload)
+  }
+
+  async orgMemberAdded(payload: AuthOrgMemberAddedPayload): Promise<void> {
+    await this.safePublish(AUTH_EVENTS.ORG_MEMBER_ADDED, payload)
+  }
+
+  async orgMemberRemoved(payload: AuthOrgMemberRemovedPayload): Promise<void> {
+    await this.safePublish(AUTH_EVENTS.ORG_MEMBER_REMOVED, payload)
+  }
+
+  async orgRoleChanged(payload: AuthOrgRoleChangedPayload): Promise<void> {
+    await this.safePublish(AUTH_EVENTS.ORG_ROLE_CHANGED, payload)
   }
 }

--- a/packages/modules/auth/src/events/types.ts
+++ b/packages/modules/auth/src/events/types.ts
@@ -34,11 +34,11 @@ export interface AuthSessionRevokedPayload {
   reason: 'user_initiated' | 'admin_revoked' | 'token_rotation' | 'expired'
 }
 
-// Future: Organizations (#59)
 export interface AuthOrgCreatedPayload {
   orgId: string
   ownerId: string
   name: string
+  type: string | null
 }
 
 export interface AuthOrgMemberAddedPayload {

--- a/packages/modules/auth/src/graphql/__generated__/resolver-types.ts
+++ b/packages/modules/auth/src/graphql/__generated__/resolver-types.ts
@@ -1,0 +1,264 @@
+import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
+import { GraphQLContext } from '../../types';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: Date | string; output: Date | string; }
+  EmailAddress: { input: string; output: string; }
+};
+
+export type CreateOrganizationInput = {
+  name: Scalars['String']['input'];
+  slug?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type Invitation = {
+  __typename?: 'Invitation';
+  email: Scalars['EmailAddress']['output'];
+  expiresAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  role: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  _empty?: Maybe<Scalars['String']['output']>;
+  acceptInvitation: OrgMember;
+  createOrganization: Organization;
+  inviteMember: Invitation;
+  removeMember: Scalars['Boolean']['output'];
+  setActiveOrganization?: Maybe<Organization>;
+};
+
+
+export type MutationAcceptInvitationArgs = {
+  invitationId: Scalars['ID']['input'];
+};
+
+
+export type MutationCreateOrganizationArgs = {
+  input: CreateOrganizationInput;
+};
+
+
+export type MutationInviteMemberArgs = {
+  email: Scalars['String']['input'];
+  organizationId: Scalars['ID']['input'];
+  role: Scalars['String']['input'];
+};
+
+
+export type MutationRemoveMemberArgs = {
+  memberIdToRemove: Scalars['ID']['input'];
+  organizationId: Scalars['ID']['input'];
+};
+
+
+export type MutationSetActiveOrganizationArgs = {
+  organizationId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+export type OrgMember = {
+  __typename?: 'OrgMember';
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  role: Scalars['String']['output'];
+  userId: Scalars['String']['output'];
+};
+
+export type Organization = {
+  __typename?: 'Organization';
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['ID']['output'];
+  logo?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  slug: Scalars['String']['output'];
+  type?: Maybe<Scalars['String']['output']>;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  _empty?: Maybe<Scalars['String']['output']>;
+  myOrganizations: Array<Organization>;
+  organization?: Maybe<Organization>;
+};
+
+
+export type QueryOrganizationArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type WithIndex<TObject> = TObject & Record<string, any>;
+export type ResolversObject<TObject> = WithIndex<TObject>;
+
+export type ResolverTypeWrapper<T> = Promise<T> | T;
+
+
+export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
+  resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
+};
+export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs> | ResolverWithResolve<TResult, TParent, TContext, TArgs>;
+
+export type ResolverFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Promise<TResult> | TResult;
+
+export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
+
+export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<{ [key in TKey]: TResult }, TParent, TContext, TArgs>;
+  resolve?: SubscriptionResolveFn<TResult, { [key in TKey]: TResult }, TContext, TArgs>;
+}
+
+export interface SubscriptionResolverObject<TResult, TParent, TContext, TArgs> {
+  subscribe: SubscriptionSubscribeFn<any, TParent, TContext, TArgs>;
+  resolve: SubscriptionResolveFn<TResult, any, TContext, TArgs>;
+}
+
+export type SubscriptionObject<TResult, TKey extends string, TParent, TContext, TArgs> =
+  | SubscriptionSubscriberObject<TResult, TKey, TParent, TContext, TArgs>
+  | SubscriptionResolverObject<TResult, TParent, TContext, TArgs>;
+
+export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TContext = {}, TArgs = {}> =
+  | ((...args: any[]) => SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>)
+  | SubscriptionObject<TResult, TKey, TParent, TContext, TArgs>;
+
+export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
+  parent: TParent,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
+
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+
+export type NextResolverFn<T> = () => Promise<T>;
+
+export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs = {}> = (
+  next: NextResolverFn<TResult>,
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => TResult | Promise<TResult>;
+
+
+
+/** Mapping between all available schema types and the resolvers types */
+export type ResolversTypes = ResolversObject<{
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  CreateOrganizationInput: CreateOrganizationInput;
+  DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  EmailAddress: ResolverTypeWrapper<Scalars['EmailAddress']['output']>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  Invitation: ResolverTypeWrapper<Invitation>;
+  Mutation: ResolverTypeWrapper<{}>;
+  OrgMember: ResolverTypeWrapper<OrgMember>;
+  Organization: ResolverTypeWrapper<Organization>;
+  Query: ResolverTypeWrapper<{}>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
+}>;
+
+/** Mapping between all available schema types and the resolvers parents */
+export type ResolversParentTypes = ResolversObject<{
+  Boolean: Scalars['Boolean']['output'];
+  CreateOrganizationInput: CreateOrganizationInput;
+  DateTime: Scalars['DateTime']['output'];
+  EmailAddress: Scalars['EmailAddress']['output'];
+  ID: Scalars['ID']['output'];
+  Invitation: Invitation;
+  Mutation: {};
+  OrgMember: OrgMember;
+  Organization: Organization;
+  Query: {};
+  String: Scalars['String']['output'];
+}>;
+
+export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
+  name: 'DateTime';
+}
+
+export interface EmailAddressScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['EmailAddress'], any> {
+  name: 'EmailAddress';
+}
+
+export type InvitationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Invitation'] = ResolversParentTypes['Invitation']> = ResolversObject<{
+  email?: Resolver<ResolversTypes['EmailAddress'], ParentType, ContextType>;
+  expiresAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  role?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type MutationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
+  _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  acceptInvitation?: Resolver<ResolversTypes['OrgMember'], ParentType, ContextType, RequireFields<MutationAcceptInvitationArgs, 'invitationId'>>;
+  createOrganization?: Resolver<ResolversTypes['Organization'], ParentType, ContextType, RequireFields<MutationCreateOrganizationArgs, 'input'>>;
+  inviteMember?: Resolver<ResolversTypes['Invitation'], ParentType, ContextType, RequireFields<MutationInviteMemberArgs, 'email' | 'organizationId' | 'role'>>;
+  removeMember?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationRemoveMemberArgs, 'memberIdToRemove' | 'organizationId'>>;
+  setActiveOrganization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, Partial<MutationSetActiveOrganizationArgs>>;
+}>;
+
+export type OrgMemberResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['OrgMember'] = ResolversParentTypes['OrgMember']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  role?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OrganizationResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Organization'] = ResolversParentTypes['Organization']> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  logo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  myOrganizations?: Resolver<Array<ResolversTypes['Organization']>, ParentType, ContextType>;
+  organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryOrganizationArgs, 'id'>>;
+}>;
+
+export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
+  DateTime?: GraphQLScalarType;
+  EmailAddress?: GraphQLScalarType;
+  Invitation?: InvitationResolvers<ContextType>;
+  Mutation?: MutationResolvers<ContextType>;
+  OrgMember?: OrgMemberResolvers<ContextType>;
+  Organization?: OrganizationResolvers<ContextType>;
+  Query?: QueryResolvers<ContextType>;
+}>;
+

--- a/packages/modules/auth/src/graphql/resolvers.test.ts
+++ b/packages/modules/auth/src/graphql/resolvers.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockRegisterResolvers = vi.hoisted(() => vi.fn())
+const mockValidateOrgType = vi.hoisted(() => vi.fn((type: string | null | undefined) => type ?? null))
+
+vi.mock('@czo/kit/graphql', () => ({
+  registerResolvers: mockRegisterResolvers,
+}))
+
+vi.mock('../services/organization-types', () => ({
+  validateOrgType: mockValidateOrgType,
+}))
+
+// eslint-disable-next-line import/first
+import './resolvers'
+
+type ResolverFn = (...args: unknown[]) => Promise<unknown>
+interface ResolverMap {
+  Query: Record<string, ResolverFn>
+  Mutation: Record<string, ResolverFn>
+}
+
+const resolvers = mockRegisterResolvers.mock.calls[0]![0] as ResolverMap
+
+describe('organization resolvers', () => {
+  const mockHeaders = new Headers({ authorization: 'Bearer test-token' })
+  const mockRequest = { headers: mockHeaders } as Request
+
+  const mockAuthInstance = {
+    api: {
+      listOrganizations: vi.fn(),
+      getFullOrganization: vi.fn(),
+      createOrganization: vi.fn(),
+      setActiveOrganization: vi.fn(),
+      createInvitation: vi.fn(),
+      removeMember: vi.fn(),
+      acceptInvitation: vi.fn(),
+    },
+  }
+
+  const mockContext = {
+    auth: {
+      session: { id: 's1', userId: 'u1', expiresAt: new Date(), actorType: 'admin', authMethod: 'email', organizationId: null },
+      user: { id: 'u1', email: 'test@czo.dev', name: 'Test' },
+      actorType: 'admin',
+      organization: null,
+      authSource: 'bearer' as const,
+    },
+    authInstance: mockAuthInstance,
+    request: mockRequest,
+  }
+
+  beforeEach(() => {
+    Object.values(mockAuthInstance.api).forEach(fn => fn.mockReset())
+  })
+
+  it('should register resolvers', () => {
+    expect(mockRegisterResolvers).toHaveBeenCalledTimes(1)
+    expect(resolvers.Query).toBeDefined()
+    expect(resolvers.Mutation).toBeDefined()
+  })
+
+  describe('query.myOrganizations', () => {
+    it('should call listOrganizations with request headers', async () => {
+      const orgs = [{ id: 'org1', name: 'Org 1', slug: 'org-1' }]
+      mockAuthInstance.api.listOrganizations.mockResolvedValue(orgs)
+
+      const result = await resolvers.Query.myOrganizations!(null, {}, mockContext)
+
+      expect(mockAuthInstance.api.listOrganizations).toHaveBeenCalledWith({
+        headers: mockHeaders,
+      })
+      expect(result).toEqual(orgs)
+    })
+
+    it('should return empty array when no organizations', async () => {
+      mockAuthInstance.api.listOrganizations.mockResolvedValue(null)
+
+      const result = await resolvers.Query.myOrganizations!(null, {}, mockContext)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('query.organization', () => {
+    it('should call getFullOrganization with id', async () => {
+      const org = { id: 'org1', name: 'Org 1', slug: 'org-1' }
+      mockAuthInstance.api.getFullOrganization.mockResolvedValue(org)
+
+      const result = await resolvers.Query.organization!(null, { id: 'org1' }, mockContext)
+
+      expect(mockAuthInstance.api.getFullOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        query: { organizationId: 'org1' },
+      })
+      expect(result).toEqual(org)
+    })
+
+    it('should return null when organization not found', async () => {
+      mockAuthInstance.api.getFullOrganization.mockResolvedValue(null)
+
+      const result = await resolvers.Query.organization!(null, { id: 'nonexistent' }, mockContext)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('mutation.createOrganization', () => {
+    it('should create organization with name and optional slug', async () => {
+      const org = { id: 'org1', name: 'My Store', slug: 'my-store' }
+      mockAuthInstance.api.createOrganization.mockResolvedValue(org)
+
+      const result = await resolvers.Mutation.createOrganization!(
+        null,
+        { input: { name: 'My Store', slug: 'my-store' } },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.createOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { name: 'My Store', slug: 'my-store' },
+      })
+      expect(result).toEqual(org)
+    })
+
+    it('should create organization without slug (auto-generated)', async () => {
+      const org = { id: 'org1', name: 'My Store', slug: 'my-store' }
+      mockAuthInstance.api.createOrganization.mockResolvedValue(org)
+
+      await resolvers.Mutation.createOrganization!(
+        null,
+        { input: { name: 'My Store' } },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.createOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { name: 'My Store' },
+      })
+    })
+
+    it('should validate and pass type when provided', async () => {
+      const org = { id: 'org1', name: 'My Store', slug: 'my-store', type: 'merchant' }
+      mockAuthInstance.api.createOrganization.mockResolvedValue(org)
+      mockValidateOrgType.mockReturnValue('merchant')
+
+      const result = await resolvers.Mutation.createOrganization!(
+        null,
+        { input: { name: 'My Store', type: 'merchant' } },
+        mockContext,
+      )
+
+      expect(mockValidateOrgType).toHaveBeenCalledWith('merchant')
+      expect(mockAuthInstance.api.createOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { name: 'My Store', type: 'merchant' },
+      })
+      expect(result).toEqual(org)
+    })
+
+    it('should not include type in body when validateOrgType returns null', async () => {
+      const org = { id: 'org1', name: 'My Store', slug: 'my-store' }
+      mockAuthInstance.api.createOrganization.mockResolvedValue(org)
+      mockValidateOrgType.mockReturnValue(null)
+
+      await resolvers.Mutation.createOrganization!(
+        null,
+        { input: { name: 'My Store' } },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.createOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { name: 'My Store' },
+      })
+    })
+
+    it('should throw when validateOrgType throws for invalid type', async () => {
+      mockValidateOrgType.mockImplementation(() => {
+        throw new Error('Invalid organization type: "bad"')
+      })
+
+      await expect(
+        resolvers.Mutation.createOrganization!(
+          null,
+          { input: { name: 'My Store', type: 'bad' } },
+          mockContext,
+        ),
+      ).rejects.toThrow('Invalid organization type')
+    })
+  })
+
+  describe('mutation.setActiveOrganization', () => {
+    it('should set active organization by id', async () => {
+      const org = { id: 'org1', name: 'Org 1', slug: 'org-1', members: [], invitations: [] }
+      mockAuthInstance.api.setActiveOrganization.mockResolvedValue(org)
+
+      const result = await resolvers.Mutation.setActiveOrganization!(
+        null,
+        { organizationId: 'org1' },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.setActiveOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { organizationId: 'org1' },
+      })
+      expect(result).toEqual(org)
+    })
+
+    it('should clear active organization when organizationId is null', async () => {
+      mockAuthInstance.api.setActiveOrganization.mockResolvedValue(null)
+
+      const result = await resolvers.Mutation.setActiveOrganization!(
+        null,
+        { organizationId: null },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.setActiveOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { organizationId: null },
+      })
+      expect(result).toBeNull()
+    })
+
+    it('should clear active organization when organizationId is undefined', async () => {
+      mockAuthInstance.api.setActiveOrganization.mockResolvedValue(null)
+
+      const result = await resolvers.Mutation.setActiveOrganization!(
+        null,
+        {},
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.setActiveOrganization).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { organizationId: null },
+      })
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('mutation.inviteMember', () => {
+    it('should create invitation with email and role', async () => {
+      const invitation = { id: 'inv1', email: 'new@czo.dev', role: 'member', status: 'pending' }
+      mockAuthInstance.api.createInvitation.mockResolvedValue(invitation)
+
+      const result = await resolvers.Mutation.inviteMember!(
+        null,
+        { organizationId: 'org1', email: 'new@czo.dev', role: 'member' },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.createInvitation).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { organizationId: 'org1', email: 'new@czo.dev', role: 'member' },
+      })
+      expect(result).toEqual(invitation)
+    })
+  })
+
+  describe('mutation.removeMember', () => {
+    it('should remove member and return true', async () => {
+      mockAuthInstance.api.removeMember.mockResolvedValue({ success: true })
+
+      const result = await resolvers.Mutation.removeMember!(
+        null,
+        { organizationId: 'org1', memberIdToRemove: 'm1' },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.removeMember).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { organizationId: 'org1', memberIdOrEmail: 'm1' },
+      })
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('mutation.acceptInvitation', () => {
+    it('should accept invitation and return member from result', async () => {
+      const member = { id: 'm1', userId: 'u2', role: 'member', createdAt: new Date().toISOString() }
+      mockAuthInstance.api.acceptInvitation.mockResolvedValue({ member, invitation: {} })
+
+      const result = await resolvers.Mutation.acceptInvitation!(
+        null,
+        { invitationId: 'inv1' },
+        mockContext,
+      )
+
+      expect(mockAuthInstance.api.acceptInvitation).toHaveBeenCalledWith({
+        headers: mockHeaders,
+        body: { invitationId: 'inv1' },
+      })
+      expect(result).toEqual(member)
+    })
+
+    it('should throw when acceptInvitation returns null', async () => {
+      mockAuthInstance.api.acceptInvitation.mockResolvedValue(null)
+
+      await expect(
+        resolvers.Mutation.acceptInvitation!(
+          null,
+          { invitationId: 'inv-bad' },
+          mockContext,
+        ),
+      ).rejects.toThrow('Failed to accept invitation')
+    })
+  })
+})

--- a/packages/modules/auth/src/graphql/resolvers.ts
+++ b/packages/modules/auth/src/graphql/resolvers.ts
@@ -1,0 +1,80 @@
+import type { MutationResolvers, QueryResolvers } from './__generated__/resolver-types'
+import { registerResolvers } from '@czo/kit/graphql'
+import { validateOrgType } from '../services/organization-types'
+
+const Query: QueryResolvers = {
+  myOrganizations: async (_parent, _args, ctx) => {
+    const result = await ctx.authInstance.api.listOrganizations({
+      headers: ctx.request.headers,
+    })
+    return result ?? []
+  },
+  organization: async (_parent, args, ctx) => {
+    const result = await ctx.authInstance.api.getFullOrganization({
+      headers: ctx.request.headers,
+      query: { organizationId: args.id },
+    })
+    return result ?? null
+  },
+}
+
+const Mutation: MutationResolvers = {
+  createOrganization: async (_parent, args, ctx) => {
+    const validatedType = validateOrgType(args.input.type)
+    const body: Record<string, unknown> = { name: args.input.name }
+    if (args.input.slug) {
+      body.slug = args.input.slug
+    }
+    if (validatedType) {
+      body.type = validatedType
+    }
+    const result = await ctx.authInstance.api.createOrganization({
+      headers: ctx.request.headers,
+      body: body as { name: string, slug: string },
+    })
+    if (!result)
+      throw new Error('Failed to create organization')
+    return result
+  },
+  setActiveOrganization: async (_parent, args, ctx) => {
+    const result = await ctx.authInstance.api.setActiveOrganization({
+      headers: ctx.request.headers,
+      body: { organizationId: args.organizationId ?? null },
+    })
+    return result ?? null
+  },
+  inviteMember: async (_parent, args, ctx) => {
+    const result = await ctx.authInstance.api.createInvitation({
+      headers: ctx.request.headers,
+      body: {
+        organizationId: args.organizationId,
+        email: args.email,
+        role: args.role as 'viewer',
+      },
+    })
+    if (!result)
+      throw new Error('Failed to create invitation')
+    return result
+  },
+  removeMember: async (_parent, args, ctx) => {
+    await ctx.authInstance.api.removeMember({
+      headers: ctx.request.headers,
+      body: {
+        organizationId: args.organizationId,
+        memberIdOrEmail: args.memberIdToRemove,
+      },
+    })
+    return true
+  },
+  acceptInvitation: async (_parent, args, ctx) => {
+    const result = await ctx.authInstance.api.acceptInvitation({
+      headers: ctx.request.headers,
+      body: { invitationId: args.invitationId },
+    })
+    if (!result)
+      throw new Error('Failed to accept invitation')
+    return result.member
+  },
+}
+
+registerResolvers({ Query, Mutation })

--- a/packages/modules/auth/src/graphql/schema/base.graphql
+++ b/packages/modules/auth/src/graphql/schema/base.graphql
@@ -1,0 +1,10 @@
+scalar DateTime
+scalar EmailAddress
+
+type Query {
+  _empty: String
+}
+
+type Mutation {
+  _empty: String
+}

--- a/packages/modules/auth/src/graphql/schema/organization.graphql
+++ b/packages/modules/auth/src/graphql/schema/organization.graphql
@@ -1,0 +1,42 @@
+type Organization {
+  id: ID!
+  name: String!
+  slug: String!
+  logo: String
+  type: String
+  createdAt: DateTime!
+}
+
+type OrgMember {
+  id: ID!
+  userId: String!
+  role: String!
+  createdAt: DateTime!
+}
+
+type Invitation {
+  id: ID!
+  email: EmailAddress!
+  role: String!
+  status: String!
+  expiresAt: DateTime
+}
+
+input CreateOrganizationInput {
+  name: String!
+  slug: String
+  type: String
+}
+
+extend type Query {
+  myOrganizations: [Organization!]!
+  organization(id: ID!): Organization
+}
+
+extend type Mutation {
+  createOrganization(input: CreateOrganizationInput!): Organization!
+  setActiveOrganization(organizationId: ID): Organization
+  inviteMember(organizationId: ID!, email: String!, role: String!): Invitation!
+  removeMember(organizationId: ID!, memberIdToRemove: ID!): Boolean!
+  acceptInvitation(invitationId: ID!): OrgMember!
+}

--- a/packages/modules/auth/src/graphql/typedefs.test.ts
+++ b/packages/modules/auth/src/graphql/typedefs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockRegisterTypeDefs = vi.hoisted(() => vi.fn())
+
+vi.mock('@czo/kit/graphql', () => ({
+  registerTypeDefs: mockRegisterTypeDefs,
+}))
+
+describe('organization typedefs', () => {
+  it('should register type definitions as a string with the kit registry', async () => {
+    await import('./typedefs')
+
+    expect(mockRegisterTypeDefs).toHaveBeenCalledTimes(1)
+    const registered = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(typeof registered).toBe('string')
+  })
+
+  it('should define Organization type with expected fields', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('type Organization')
+    expect(sdl).toContain('id: ID!')
+    expect(sdl).toContain('name: String!')
+    expect(sdl).toContain('slug: String!')
+    expect(sdl).toContain('logo: String')
+    expect(sdl).toContain('type: String')
+    expect(sdl).toContain('createdAt: DateTime!')
+  })
+
+  it('should define OrgMember type', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('type OrgMember')
+    expect(sdl).toContain('userId: String!')
+    expect(sdl).toContain('role: String!')
+  })
+
+  it('should define Invitation type with scalars', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('type Invitation')
+    expect(sdl).toContain('email: EmailAddress!')
+    expect(sdl).toContain('expiresAt: DateTime')
+  })
+
+  it('should extend Query with myOrganizations and organization', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('extend type Query')
+    expect(sdl).toContain('myOrganizations: [Organization!]!')
+    expect(sdl).toContain('organization(id: ID!): Organization')
+  })
+
+  it('should extend Mutation with org operations', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('extend type Mutation')
+    expect(sdl).toContain('createOrganization')
+    expect(sdl).toContain('setActiveOrganization')
+    expect(sdl).toContain('inviteMember')
+    expect(sdl).toContain('removeMember')
+    expect(sdl).toContain('acceptInvitation')
+  })
+
+  it('should define CreateOrganizationInput with type field', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
+    expect(sdl).toContain('input CreateOrganizationInput')
+    expect(sdl).toContain('type: String')
+  })
+})

--- a/packages/modules/auth/src/graphql/typedefs.ts
+++ b/packages/modules/auth/src/graphql/typedefs.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { registerTypeDefs } from '@czo/kit/graphql'
+
+const schemaDir = resolve(import.meta.dirname, 'schema')
+const orgSchema = readFileSync(resolve(schemaDir, 'organization.graphql'), 'utf-8')
+
+registerTypeDefs(orgSchema)

--- a/packages/modules/auth/src/plugins/index.ts
+++ b/packages/modules/auth/src/plugins/index.ts
@@ -12,6 +12,8 @@ import { createJwtBlocklist } from '../services/jwt-blocklist'
 import { useAuthRedis } from '../services/redis'
 import { createRedisStorage } from '../services/secondary-storage'
 import { createTokenRotationService } from '../services/token-rotation'
+import '../graphql/typedefs'
+import '../graphql/resolvers'
 
 export default definePlugin(async (nitroApp) => {
   const logger = useLogger('auth:plugin')

--- a/packages/modules/auth/src/routes/auth/[actor]/[...all].ts
+++ b/packages/modules/auth/src/routes/auth/[actor]/[...all].ts
@@ -11,6 +11,45 @@ const TOKEN_RESPONSE_PATHS = new Set([
   '/sign-up/email',
 ])
 
+interface OrganizationFields {
+  name?: string
+  type?: string
+}
+
+async function parseOrganizationFields(req: Request): Promise<OrganizationFields> {
+  try {
+    const body = await req.json() as Record<string, unknown>
+    const fields: OrganizationFields = {}
+    if (typeof body.organizationName === 'string' && body.organizationName.trim()) {
+      fields.name = body.organizationName.trim()
+    }
+    if (typeof body.organizationType === 'string' && body.organizationType.trim()) {
+      fields.type = body.organizationType.trim()
+    }
+    return fields
+  }
+  catch {
+    // Not JSON or no organization fields — ignore
+  }
+  return {}
+}
+
+async function autoCreateOrganization(auth: Auth, sessionToken: string, fields: OrganizationFields): Promise<void> {
+  try {
+    const body: Record<string, unknown> = { name: fields.name }
+    if (fields.type) {
+      body.type = fields.type
+    }
+    await auth.api.createOrganization({
+      headers: new Headers({ authorization: `Bearer ${sessionToken}` }),
+      body: body as { name: string, slug: string },
+    })
+  }
+  catch {
+    // Best-effort: sign-up succeeded, org creation is non-blocking
+  }
+}
+
 export default defineHandler(async (event) => {
   const auth = (event.context as Record<string, unknown>).auth as Auth | undefined
 
@@ -29,6 +68,15 @@ export default defineHandler(async (event) => {
   // Rewrite URL: strip /{actor}/ segment so better-auth sees /api/auth/...
   const url = new URL(event.req.url)
   url.pathname = url.pathname.replace(`/auth/${actor}/`, '/auth/')
+
+  // For sign-up, check if organization fields are provided before consuming the body
+  const remainingPath = url.pathname.replace(/^\/api\/auth/, '')
+  const isSignUp = remainingPath === '/sign-up/email'
+  let orgFields: OrganizationFields = {}
+  if (isSignUp) {
+    orgFields = await parseOrganizationFields(event.req.clone())
+  }
+
   const rewrittenReq = new Request(url, event.req)
 
   const response = await runWithSessionContext(
@@ -37,11 +85,15 @@ export default defineHandler(async (event) => {
   )
 
   // Transform sign-in/sign-up responses to dual-token format
-  const remainingPath = url.pathname.replace(/^\/api\/auth/, '')
   if (response.ok && TOKEN_RESPONSE_PATHS.has(remainingPath)) {
     try {
       const data = await response.json() as { session?: { token?: string }, user?: unknown }
       if (data?.session?.token) {
+        // Auto-create organization on sign-up when organizationName is provided
+        if (isSignUp && orgFields.name) {
+          void autoCreateOrganization(auth, data.session.token, orgFields)
+        }
+
         const tokenResponse = await auth.api.getToken({
           headers: new Headers({
             authorization: `Bearer ${data.session.token}`,

--- a/packages/modules/auth/src/services/email.service.ts
+++ b/packages/modules/auth/src/services/email.service.ts
@@ -7,9 +7,17 @@ export interface EmailParams {
   token: string
 }
 
+export interface InvitationEmailParams {
+  to: string
+  organizationName: string
+  inviterName: string
+  invitationId: string
+}
+
 export interface EmailService {
   sendVerificationEmail: (params: EmailParams) => Promise<void>
   sendPasswordResetEmail: (params: EmailParams) => Promise<void>
+  sendInvitationEmail: (params: InvitationEmailParams) => Promise<void>
 }
 
 export class ConsoleEmailService implements EmailService {
@@ -32,6 +40,15 @@ export class ConsoleEmailService implements EmailService {
       to: params.to,
       userName: params.userName,
       url: params.url,
+    })
+  }
+
+  async sendInvitationEmail(params: InvitationEmailParams): Promise<void> {
+    this.logger.info('[Organization Invitation Email]', {
+      to: params.to,
+      organizationName: params.organizationName,
+      inviterName: params.inviterName,
+      invitationId: params.invitationId,
     })
   }
 }

--- a/packages/modules/auth/src/services/organization-roles.test.ts
+++ b/packages/modules/auth/src/services/organization-roles.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { ac, ORG_ROLES, statements, viewerRole } from './organization-roles'
+
+describe('organization-roles', () => {
+  describe('statements', () => {
+    it('should define organization actions', () => {
+      expect(statements.organization).toEqual(['read', 'update', 'delete'])
+    })
+
+    it('should define member actions', () => {
+      expect(statements.member).toEqual(['read', 'create', 'update', 'delete'])
+    })
+
+    it('should define invitation actions', () => {
+      expect(statements.invitation).toEqual(['read', 'create', 'cancel'])
+    })
+  })
+
+  describe('viewerRole', () => {
+    it('should wrap permissions under statements key', () => {
+      expect(viewerRole.statements).toBeDefined()
+    })
+
+    it('should have read-only permissions for organization', () => {
+      expect(viewerRole.statements.organization).toEqual(['read'])
+    })
+
+    it('should have read-only permissions for member', () => {
+      expect(viewerRole.statements.member).toEqual(['read'])
+    })
+
+    it('should have read-only permissions for invitation', () => {
+      expect(viewerRole.statements.invitation).toEqual(['read'])
+    })
+  })
+
+  describe('ac', () => {
+    it('should be a valid access control instance', () => {
+      expect(ac).toBeDefined()
+      expect(ac.statements).toBeDefined()
+    })
+
+    it('should expose a newRole factory', () => {
+      expect(typeof ac.newRole).toBe('function')
+    })
+  })
+
+  describe('oRG_ROLES', () => {
+    it('should define all four roles', () => {
+      expect(ORG_ROLES).toEqual({
+        OWNER: 'owner',
+        ADMIN: 'admin',
+        MEMBER: 'member',
+        VIEWER: 'viewer',
+      })
+    })
+  })
+})

--- a/packages/modules/auth/src/services/organization-roles.ts
+++ b/packages/modules/auth/src/services/organization-roles.ts
@@ -1,0 +1,24 @@
+import { createAccessControl, role } from 'better-auth/plugins/access'
+
+export const statements = {
+  organization: ['read', 'update', 'delete'],
+  member: ['read', 'create', 'update', 'delete'],
+  invitation: ['read', 'create', 'cancel'],
+} as const
+
+export const ac = createAccessControl(statements)
+
+export const viewerRole = role({
+  organization: ['read'],
+  member: ['read'],
+  invitation: ['read'],
+})
+
+export const ORG_ROLES = {
+  OWNER: 'owner',
+  ADMIN: 'admin',
+  MEMBER: 'member',
+  VIEWER: 'viewer',
+} as const
+
+export type OrgRole = (typeof ORG_ROLES)[keyof typeof ORG_ROLES]

--- a/packages/modules/auth/src/services/organization-types.test.ts
+++ b/packages/modules/auth/src/services/organization-types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { isValidOrgType, ORG_TYPES, validateOrgType } from './organization-types'
+
+describe('organization types', () => {
+  describe('orgTypes', () => {
+    it('should contain all expected types', () => {
+      expect(ORG_TYPES).toEqual(['merchant', 'delivery', 'warehouse', 'supplier'])
+    })
+
+    it('should have 4 entries', () => {
+      expect(ORG_TYPES).toHaveLength(4)
+    })
+  })
+
+  describe('isValidOrgType', () => {
+    it.each(ORG_TYPES)('should return true for valid type: %s', (type) => {
+      expect(isValidOrgType(type)).toBe(true)
+    })
+
+    it('should return false for invalid type', () => {
+      expect(isValidOrgType('invalid')).toBe(false)
+    })
+
+    it('should return false for empty string', () => {
+      expect(isValidOrgType('')).toBe(false)
+    })
+  })
+
+  describe('validateOrgType', () => {
+    it.each(ORG_TYPES)('should return the type for valid input: %s', (type) => {
+      expect(validateOrgType(type)).toBe(type)
+    })
+
+    it('should return null for null input', () => {
+      expect(validateOrgType(null)).toBeNull()
+    })
+
+    it('should return null for undefined input', () => {
+      expect(validateOrgType(undefined)).toBeNull()
+    })
+
+    it('should return null for empty string', () => {
+      expect(validateOrgType('')).toBeNull()
+    })
+
+    it('should throw for invalid type', () => {
+      expect(() => validateOrgType('invalid')).toThrow(
+        'Invalid organization type: "invalid". Must be one of: merchant, delivery, warehouse, supplier',
+      )
+    })
+  })
+})

--- a/packages/modules/auth/src/services/organization-types.ts
+++ b/packages/modules/auth/src/services/organization-types.ts
@@ -1,0 +1,15 @@
+export const ORG_TYPES = ['merchant', 'delivery', 'warehouse', 'supplier'] as const
+export type OrgType = (typeof ORG_TYPES)[number]
+
+export function isValidOrgType(type: string): type is OrgType {
+  return (ORG_TYPES as readonly string[]).includes(type)
+}
+
+export function validateOrgType(type: string | null | undefined): string | null {
+  if (type == null || type === '')
+    return null
+  if (!isValidOrgType(type)) {
+    throw new Error(`Invalid organization type: "${type}". Must be one of: ${ORG_TYPES.join(', ')}`)
+  }
+  return type
+}

--- a/packages/modules/auth/src/types.ts
+++ b/packages/modules/auth/src/types.ts
@@ -1,3 +1,5 @@
+import type { Auth } from './config/auth.config'
+
 export interface AuthContext {
   session: {
     id: string
@@ -19,4 +21,6 @@ export interface AuthContext {
 
 export interface GraphQLContext {
   auth: AuthContext
+  authInstance: Auth
+  request: Request
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ catalogs:
     graphql:
       specifier: ^16.11.0
       version: 16.12.0
+    graphql-scalars:
+      specifier: ^1.24.0
+      version: 1.25.0
     graphql-yoga:
       specifier: ^5.16.0
       version: 5.18.0
@@ -118,6 +121,10 @@ catalogs:
     zod:
       specifier: ^4.1.11
       version: 4.3.4
+  default:
+    '@graphql-tools/schema':
+      specifier: ^10.0.25
+      version: 10.0.30
   dev:
     '@antfu/eslint-config':
       specifier: ^5.4.1
@@ -128,6 +135,15 @@ catalogs:
     '@eslint-react/eslint-plugin':
       specifier: ^1.52.6
       version: 1.53.1
+    '@graphql-codegen/cli':
+      specifier: ^6.0.1
+      version: 6.1.0
+    '@graphql-codegen/typescript':
+      specifier: ^4.1.6
+      version: 4.1.6
+    '@graphql-codegen/typescript-resolvers':
+      specifier: ^4.4.6
+      version: 4.5.2
     '@next/eslint-plugin-next':
       specifier: ^15.4.5
       version: 15.5.9
@@ -292,6 +308,9 @@ importers:
       '@graphql-tools/merge':
         specifier: catalog:common
         version: 9.1.6(graphql@16.12.0)
+      '@graphql-tools/schema':
+        specifier: 'catalog:'
+        version: 10.0.30(graphql@16.12.0)
       graphql:
         specifier: catalog:common
         version: 16.12.0
@@ -429,6 +448,9 @@ importers:
       exsolve:
         specifier: catalog:common
         version: 1.0.8
+      graphql-scalars:
+        specifier: catalog:common
+        version: 1.25.0(graphql@16.12.0)
       hookable:
         specifier: catalog:dev
         version: 5.5.3
@@ -500,6 +522,15 @@ importers:
         specifier: catalog:common
         version: 5.9.2
     devDependencies:
+      '@graphql-codegen/cli':
+        specifier: catalog:dev
+        version: 6.1.0(@types/node@24.10.4)(graphql@16.12.0)(typescript@5.9.3)
+      '@graphql-codegen/typescript':
+        specifier: catalog:dev
+        version: 4.1.6(graphql@16.12.0)
+      '@graphql-codegen/typescript-resolvers':
+        specifier: catalog:dev
+        version: 4.5.2(graphql@16.12.0)
       '@vitest/coverage-v8':
         specifier: catalog:testing
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
@@ -1430,9 +1461,20 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
+  '@graphql-codegen/plugin-helpers@5.1.1':
+    resolution: {integrity: sha512-28GHODK2HY1NhdyRcPP3sCz0Kqxyfiz7boIZ8qIxFYmpLYnlDgiYok5fhFLVSZihyOpCs4Fa37gVHf/Q4I2FEg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
   '@graphql-codegen/plugin-helpers@6.1.0':
     resolution: {integrity: sha512-JJypehWTcty9kxKiqH7TQOetkGdOYjY78RHlI+23qB59cV2wxjFFVf8l7kmuXS4cpGVUNfIjFhVr7A1W7JMtdA==}
     engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/schema-ast@4.1.0':
+    resolution: {integrity: sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
@@ -1458,6 +1500,16 @@ packages:
       graphql-sock:
         optional: true
 
+  '@graphql-codegen/typescript-resolvers@4.5.2':
+    resolution: {integrity: sha512-u7Zz30UmtJCOmfAIcCYefS/3lE8LK7bF0COPz4VOva5v/EuxmLNCFreCuj4dztEZzBmuwJOJRm278MAxiz0fzg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-sock: ^1.0.0
+    peerDependenciesMeta:
+      graphql-sock:
+        optional: true
+
   '@graphql-codegen/typescript-resolvers@5.1.5':
     resolution: {integrity: sha512-eIheL41Whjs03sJOwBEYpWA6ISQdf4vgN3rXXm57sWuMlZJPYc/cR+vaP9GJdRp14XBQJ8tfKsrtjG5NtPpp3w==}
     engines: {node: '>=16'}
@@ -1468,11 +1520,23 @@ packages:
       graphql-sock:
         optional: true
 
+  '@graphql-codegen/typescript@4.1.6':
+    resolution: {integrity: sha512-vpw3sfwf9A7S+kIUjyFxuvrywGxd4lmwmyYnnDVjVE4kSQ6Td3DpqaPTy8aNQ6O96vFoi/bxbZS2BW49PwSUUA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
   '@graphql-codegen/typescript@5.0.7':
     resolution: {integrity: sha512-kZwcu9Iat5RWXxLGPnDbG6qVbGTigF25/aGqCG/DCQ1Al8RufSjVXhIOkJBp7QWAqXn3AupHXL1WTMXP7xs4dQ==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/visitor-plugin-common@5.8.0':
+    resolution: {integrity: sha512-lC1E1Kmuzi3WZUlYlqB4fP6+CvbKH9J+haU1iWmgsBx5/sO2ROeXJG4Dmt8gP03bI2BwjiwV5WxCEMlyeuzLnA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   '@graphql-codegen/visitor-plugin-common@6.2.2':
     resolution: {integrity: sha512-wEJ4zJj58PKlXISItZfr0xIHyM1lAuRfoflPegsb1L17Mx5+YzNOy0WAlLele3yzyV89WvCiprFKMcVQ7KfDXg==}
@@ -3859,6 +3923,10 @@ packages:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
 
+  dependency-graph@0.11.0:
+    resolution: {integrity: sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==}
+    engines: {node: '>= 0.6.0'}
+
   dependency-graph@1.0.0:
     resolution: {integrity: sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==}
     engines: {node: '>=4'}
@@ -4647,6 +4715,12 @@ packages:
     peerDependenciesMeta:
       cosmiconfig-toml-loader:
         optional: true
+
+  graphql-scalars@1.25.0:
+    resolution: {integrity: sha512-b0xyXZeRFkne4Eq7NAnL400gStGqG/Sx9VqX0A05nHyEbv57UJnWKsjNnrpVqv5e/8N1MUxkt0wwcRXbiyKcFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   graphql-tag@2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -7924,6 +7998,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@graphql-codegen/plugin-helpers@5.1.1(graphql@16.12.0)':
+    dependencies:
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 16.12.0
+      import-from: 4.0.0
+      lodash: 4.17.21
+      tslib: 2.6.3
+
   '@graphql-codegen/plugin-helpers@6.1.0(graphql@16.12.0)':
     dependencies:
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
@@ -7932,6 +8016,13 @@ snapshots:
       graphql: 16.12.0
       import-from: 4.0.0
       lodash: 4.17.21
+      tslib: 2.6.3
+
+  '@graphql-codegen/schema-ast@4.1.0(graphql@16.12.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.12.0)
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      graphql: 16.12.0
       tslib: 2.6.3
 
   '@graphql-codegen/schema-ast@5.0.0(graphql@16.12.0)':
@@ -7963,12 +8054,35 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@graphql-codegen/typescript-resolvers@4.5.2(graphql@16.12.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.12.0)
+      '@graphql-codegen/typescript': 4.1.6(graphql@16.12.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.12.0)
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      auto-bind: 4.0.0
+      graphql: 16.12.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
   '@graphql-codegen/typescript-resolvers@5.1.5(graphql@16.12.0)':
     dependencies:
       '@graphql-codegen/plugin-helpers': 6.1.0(graphql@16.12.0)
       '@graphql-codegen/typescript': 5.0.7(graphql@16.12.0)
       '@graphql-codegen/visitor-plugin-common': 6.2.2(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      auto-bind: 4.0.0
+      graphql: 16.12.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/typescript@4.1.6(graphql@16.12.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.12.0)
+      '@graphql-codegen/schema-ast': 4.1.0(graphql@16.12.0)
+      '@graphql-codegen/visitor-plugin-common': 5.8.0(graphql@16.12.0)
       auto-bind: 4.0.0
       graphql: 16.12.0
       tslib: 2.6.3
@@ -7982,6 +8096,22 @@ snapshots:
       '@graphql-codegen/visitor-plugin-common': 6.2.2(graphql@16.12.0)
       auto-bind: 4.0.0
       graphql: 16.12.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - encoding
+
+  '@graphql-codegen/visitor-plugin-common@5.8.0(graphql@16.12.0)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 5.1.1(graphql@16.12.0)
+      '@graphql-tools/optimize': 2.0.0(graphql@16.12.0)
+      '@graphql-tools/relay-operation-optimizer': 7.0.26(graphql@16.12.0)
+      '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 16.12.0
+      graphql-tag: 2.12.6(graphql@16.12.0)
+      parse-filepath: 1.0.2
       tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
@@ -10313,6 +10443,8 @@ snapshots:
 
   denque@2.1.0: {}
 
+  dependency-graph@0.11.0: {}
+
   dependency-graph@1.0.0: {}
 
   dequal@2.0.3: {}
@@ -11234,6 +11366,11 @@ snapshots:
       - typescript
       - uWebSockets.js
       - utf-8-validate
+
+  graphql-scalars@1.25.0(graphql@16.12.0):
+    dependencies:
+      graphql: 16.12.0
+      tslib: 2.8.1
 
   graphql-tag@2.12.6(graphql@16.12.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,7 @@ catalog:
   '@dnd-kit/core': ^6.1.0
   '@dnd-kit/sortable': ^8.0.0
   '@dnd-kit/utilities': ^3.2.2
-  '@eddeee888/gcg-typescript-resolver-files': ^0.0.0
-  '@graphql-codegen/cli': ^0.0.0
+  '@eddeee888/gcg-typescript-resolver-files': ^0.14.0
   '@graphql-tools/schema': ^10.0.25
   '@hookform/error-message': ^2.0.1
   '@hookform/resolvers': 3.4.2
@@ -128,6 +127,7 @@ catalogs:
     fs-exists-cached: ^1.0.0
     fs-extra: ^11.2.0
     graphql: ^16.11.0
+    graphql-scalars: ^1.24.0
     graphql-yoga: ^5.16.0
     ioredis: ^5.0.0
     is-valid-path: ^0.1.1
@@ -153,6 +153,9 @@ catalogs:
     zod: ^4.1.11
   dev:
     '@antfu/eslint-config': ^5.4.1
+    '@graphql-codegen/cli': ^6.0.1
+    '@graphql-codegen/typescript': ^4.1.6
+    '@graphql-codegen/typescript-resolvers': ^4.4.6
     '@eddeee888/gcg-typescript-resolver-files': ^0.14.0
     '@eslint-react/eslint-plugin': ^1.52.6
     '@next/eslint-plugin-next': ^15.4.5


### PR DESCRIPTION
## Summary

- Implement multi-tenant organizations with roles (owner/admin/member/viewer), invitations, and member management via better-auth organization plugin
- Add organization types (`merchant`, `delivery`, `warehouse`, `supplier`) with server-side validation and `type` column on organizations table
- Migrate GraphQL tooling from inline SDL + manual types to `.graphql` schema files + `graphql-codegen` generated resolver types + `graphql-scalars` (DateTime, EmailAddress)

## Changes

### Phase 1 — Organizations + Types
- **Schema**: Add `type: text('type')` nullable column to `organizations` table + migration `0004`
- **Validation**: `organization-types.ts` — `ORG_TYPES` const array, `isValidOrgType()`, `validateOrgType()`
- **Roles**: `organization-roles.ts` — RBAC with `owner`, `admin`, `member`, `viewer` roles via `createAccessControl`
- **Events**: Add `type: string | null` to `AuthOrgCreatedPayload`, forward in `afterCreateOrganization` hook
- **Config**: Add `additionalFields.type` to better-auth organization schema
- **REST**: Extract `organizationType` from sign-up body, pass to `autoCreateOrganization`
- **GraphQL**: Add `type` field to `Organization` type and `CreateOrganizationInput`, validate in resolver

### Phase 2 — GraphQL Tooling
- **Kit**: Widen `registerTypeDefs()` to accept `string | DocumentNode`, add `graphql-scalars` with DateTime/EmailAddress scalar resolvers
- **Schema files**: `organization.graphql` with proper scalar types (`DateTime!`, `EmailAddress!`)
- **Codegen**: `codegen.ts` config generating typed resolvers with `GraphQLContext`
- **Resolvers**: Use generated `MutationResolvers`/`QueryResolvers` types — caught and fixed `acceptInvitation` returning wrapper instead of `.member`
- **App**: Switch `apps/mazo` from `createSchema` to `makeExecutableSchema` from `@graphql-tools/schema`

## Test plan

- [x] 388 tests pass across 26 files in `@czo/auth`
- [x] 7 tests pass in `@czo/kit` graphql module
- [x] Lint passes with zero warnings (`@czo/auth` + `@czo/kit`)
- [x] Build succeeds for both `@czo/auth` and `@czo/kit`
- [x] Organization types validation: valid types, invalid types, null/undefined/empty, error messages
- [x] GraphQL resolvers: createOrganization with type, acceptInvitation returns member, null guards
- [x] Auto-create org on sign-up with organizationType forwarding
- [x] Event payloads include type field

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)