### PR TITLE
feat(auth): add AuthRestrictionRegistry (#62)

### DIFF
--- a/apps/mazo/api/graphql.ts
+++ b/apps/mazo/api/graphql.ts
@@ -50,6 +50,7 @@ export default defineHandler(async (event) => {
   return yoga.fetch(event.req, {
     auth: authContext,
     authInstance: event.context.auth,
+    authRestrictions: event.context.authRestrictions,
     request: event.req,
   })
 })

--- a/packages/modules/auth/src/events/auth-events.test.ts
+++ b/packages/modules/auth/src/events/auth-events.test.ts
@@ -223,6 +223,21 @@ describe('authEventsService', () => {
     })
   })
 
+  describe('restrictionDenied', () => {
+    it('should publish auth.restriction.denied event with correct payload', async () => {
+      const payload = { actorType: 'customer', authMethod: 'oauth:github', reason: 'Not allowed' }
+
+      await service.restrictionDenied(payload)
+
+      expect(mockCreateDomainEvent).toHaveBeenCalledWith({
+        type: AUTH_EVENTS.RESTRICTION_DENIED,
+        payload,
+        metadata: { source: 'auth' },
+      })
+      expect(mockPublish).toHaveBeenCalled()
+    })
+  })
+
   describe('safePublish (fire-and-forget)', () => {
     it('should catch and log errors without throwing', async () => {
       mockPublish.mockRejectedValueOnce(new Error('Bus offline'))

--- a/packages/modules/auth/src/events/auth-events.ts
+++ b/packages/modules/auth/src/events/auth-events.ts
@@ -8,6 +8,7 @@ import type {
   AuthOrgMemberAddedPayload,
   AuthOrgMemberRemovedPayload,
   AuthOrgRoleChangedPayload,
+  AuthRestrictionDeniedPayload,
   AuthSessionCreatedPayload,
   AuthSessionRevokedPayload,
   AuthUserRegisteredPayload,
@@ -96,5 +97,9 @@ export class AuthEventsService {
 
   async apiKeyRevoked(payload: AuthApiKeyRevokedPayload): Promise<void> {
     await this.safePublish(AUTH_EVENTS.API_KEY_REVOKED, payload)
+  }
+
+  async restrictionDenied(payload: AuthRestrictionDeniedPayload): Promise<void> {
+    await this.safePublish(AUTH_EVENTS.RESTRICTION_DENIED, payload)
   }
 }

--- a/packages/modules/auth/src/events/types.test.ts
+++ b/packages/modules/auth/src/events/types.test.ts
@@ -5,6 +5,7 @@ import type {
   AuthApiKeyCreatedPayload,
   AuthApiKeyRevokedPayload,
   AuthEventType,
+  AuthRestrictionDeniedPayload,
   AuthSessionCreatedPayload,
   AuthSessionRevokedPayload,
   AuthUserRegisteredPayload,
@@ -15,8 +16,8 @@ import { AUTH_EVENTS } from './types'
 
 describe('auth event types', () => {
   describe('auth events constants', () => {
-    it('should define all 12 routing keys', () => {
-      expect(Object.keys(AUTH_EVENTS)).toHaveLength(12)
+    it('should define all 13 routing keys', () => {
+      expect(Object.keys(AUTH_EVENTS)).toHaveLength(13)
     })
 
     it('should use auth.* dot-delimited prefix', () => {
@@ -47,6 +48,10 @@ describe('auth event types', () => {
     it('should have correct routing keys for API key events', () => {
       expect(AUTH_EVENTS.API_KEY_CREATED).toBe('auth.api-key.created')
       expect(AUTH_EVENTS.API_KEY_REVOKED).toBe('auth.api-key.revoked')
+    })
+
+    it('should have correct routing key for restriction denied event', () => {
+      expect(AUTH_EVENTS.RESTRICTION_DENIED).toBe('auth.restriction.denied')
     })
   })
 
@@ -179,6 +184,15 @@ describe('auth event types', () => {
       }
       expect(p).toEqual({ apiKeyId: 'ak1', userId: 'u1' })
     })
+
+    it('should enforce required fields on AuthRestrictionDeniedPayload', () => {
+      const p: AuthRestrictionDeniedPayload = {
+        actorType: 'customer',
+        authMethod: 'oauth:github',
+        reason: 'Not allowed',
+      }
+      expect(p).toEqual({ actorType: 'customer', authMethod: 'oauth:github', reason: 'Not allowed' })
+    })
   })
 
   describe('authEventType union', () => {
@@ -196,8 +210,9 @@ describe('auth event types', () => {
         'auth.2fa.disabled',
         'auth.api-key.created',
         'auth.api-key.revoked',
+        'auth.restriction.denied',
       ]
-      expect(types).toHaveLength(12)
+      expect(types).toHaveLength(13)
     })
   })
 })

--- a/packages/modules/auth/src/events/types.ts
+++ b/packages/modules/auth/src/events/types.ts
@@ -79,6 +79,12 @@ export interface AuthApiKeyRevokedPayload {
   userId: string
 }
 
+export interface AuthRestrictionDeniedPayload {
+  actorType: string
+  authMethod: string
+  reason: string
+}
+
 // ─── Routing key constants ─────────────────────────────────────────────
 
 export const AUTH_EVENTS = {
@@ -94,6 +100,7 @@ export const AUTH_EVENTS = {
   TWO_FA_DISABLED: 'auth.2fa.disabled',
   API_KEY_CREATED: 'auth.api-key.created',
   API_KEY_REVOKED: 'auth.api-key.revoked',
+  RESTRICTION_DENIED: 'auth.restriction.denied',
 } as const
 
 export type AuthEventType = (typeof AUTH_EVENTS)[keyof typeof AUTH_EVENTS]
@@ -114,5 +121,6 @@ declare module '@czo/kit/event-bus' {
     'auth.2fa.disabled': Auth2FADisabledPayload
     'auth.api-key.created': AuthApiKeyCreatedPayload
     'auth.api-key.revoked': AuthApiKeyRevokedPayload
+    'auth.restriction.denied': AuthRestrictionDeniedPayload
   }
 }

--- a/packages/modules/auth/src/graphql/__generated__/resolver-types.ts
+++ b/packages/modules/auth/src/graphql/__generated__/resolver-types.ts
@@ -19,6 +19,16 @@ export type Scalars = {
   EmailAddress: { input: string; output: string; }
 };
 
+export type AuthConfig = {
+  __typename?: 'AuthConfig';
+  require2FA: Scalars['Boolean']['output'];
+  sessionDuration: Scalars['Int']['output'];
+  allowImpersonation: Scalars['Boolean']['output'];
+  dominantActorType: Scalars['String']['output'];
+  allowedMethods: Array<Scalars['String']['output']>;
+  actorTypes: Array<Scalars['String']['output']>;
+};
+
 export type ApiKey = {
   __typename?: 'ApiKey';
   createdAt: Scalars['DateTime']['output'];
@@ -106,6 +116,7 @@ export type Query = {
   __typename?: 'Query';
   _empty?: Maybe<Scalars['String']['output']>;
   myApiKeys: Array<ApiKey>;
+  myAuthConfig: AuthConfig;
   myOrganizations: Array<Organization>;
   organization?: Maybe<Organization>;
 };
@@ -188,6 +199,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
   ApiKey: ResolverTypeWrapper<ApiKey>;
+  AuthConfig: ResolverTypeWrapper<AuthConfig>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   CreateOrganizationInput: CreateOrganizationInput;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
@@ -204,6 +216,7 @@ export type ResolversTypes = ResolversObject<{
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
   ApiKey: ApiKey;
+  AuthConfig: AuthConfig;
   Boolean: Scalars['Boolean']['output'];
   CreateOrganizationInput: CreateOrganizationInput;
   DateTime: Scalars['DateTime']['output'];
@@ -224,6 +237,16 @@ export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversT
 export interface EmailAddressScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['EmailAddress'], any> {
   name: 'EmailAddress';
 }
+
+export type AuthConfigResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['AuthConfig'] = ResolversParentTypes['AuthConfig']> = ResolversObject<{
+  require2FA?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  sessionDuration?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  allowImpersonation?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  dominantActorType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  allowedMethods?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  actorTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export type ApiKeyResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ApiKey'] = ResolversParentTypes['ApiKey']> = ResolversObject<{
   createdAt?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
@@ -276,12 +299,14 @@ export type OrganizationResolvers<ContextType = GraphQLContext, ParentType exten
 export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   _empty?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   myApiKeys?: Resolver<Array<ResolversTypes['ApiKey']>, ParentType, ContextType>;
+  myAuthConfig?: Resolver<ResolversTypes['AuthConfig'], ParentType, ContextType>;
   myOrganizations?: Resolver<Array<ResolversTypes['Organization']>, ParentType, ContextType>;
   organization?: Resolver<Maybe<ResolversTypes['Organization']>, ParentType, ContextType, RequireFields<QueryOrganizationArgs, 'id'>>;
 }>;
 
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   ApiKey?: ApiKeyResolvers<ContextType>;
+  AuthConfig?: AuthConfigResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
   EmailAddress?: GraphQLScalarType;
   Invitation?: InvitationResolvers<ContextType>;

--- a/packages/modules/auth/src/graphql/resolvers.ts
+++ b/packages/modules/auth/src/graphql/resolvers.ts
@@ -3,6 +3,9 @@ import { registerResolvers } from '@czo/kit/graphql'
 import { validateOrgType } from '../services/organization-types'
 
 const Query: QueryResolvers = {
+  myAuthConfig: async (_parent, _args, ctx) => {
+    return ctx.authRestrictions.getEffectiveConfig(ctx.auth.user.id)
+  },
   myOrganizations: async (_parent, _args, ctx) => {
     const result = await ctx.authInstance.api.listOrganizations({
       headers: ctx.request.headers,

--- a/packages/modules/auth/src/graphql/schema/auth-config.graphql
+++ b/packages/modules/auth/src/graphql/schema/auth-config.graphql
@@ -1,0 +1,12 @@
+type AuthConfig {
+  require2FA: Boolean!
+  sessionDuration: Int!
+  allowImpersonation: Boolean!
+  dominantActorType: String!
+  allowedMethods: [String!]!
+  actorTypes: [String!]!
+}
+
+extend type Query {
+  myAuthConfig: AuthConfig!
+}

--- a/packages/modules/auth/src/graphql/typedefs.test.ts
+++ b/packages/modules/auth/src/graphql/typedefs.test.ts
@@ -10,11 +10,13 @@ describe('auth typedefs', () => {
   it('should register type definitions as strings with the kit registry', async () => {
     await import('./typedefs')
 
-    expect(mockRegisterTypeDefs).toHaveBeenCalledTimes(2)
+    expect(mockRegisterTypeDefs).toHaveBeenCalledTimes(3)
     const orgSdl = mockRegisterTypeDefs.mock.calls[0]![0] as string
     const apiKeySdl = mockRegisterTypeDefs.mock.calls[1]![0] as string
+    const authConfigSdl = mockRegisterTypeDefs.mock.calls[2]![0] as string
     expect(typeof orgSdl).toBe('string')
     expect(typeof apiKeySdl).toBe('string')
+    expect(typeof authConfigSdl).toBe('string')
   })
 
   it('should define Organization type with expected fields', () => {
@@ -82,5 +84,22 @@ describe('auth typedefs', () => {
     const sdl = mockRegisterTypeDefs.mock.calls[1]![0] as string
     expect(sdl).toContain('extend type Query')
     expect(sdl).toContain('myApiKeys: [ApiKey!]!')
+  })
+
+  it('should define AuthConfig type with expected fields', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[2]![0] as string
+    expect(sdl).toContain('type AuthConfig')
+    expect(sdl).toContain('require2FA: Boolean!')
+    expect(sdl).toContain('sessionDuration: Int!')
+    expect(sdl).toContain('allowImpersonation: Boolean!')
+    expect(sdl).toContain('dominantActorType: String!')
+    expect(sdl).toContain('allowedMethods: [String!]!')
+    expect(sdl).toContain('actorTypes: [String!]!')
+  })
+
+  it('should extend Query with myAuthConfig', () => {
+    const sdl = mockRegisterTypeDefs.mock.calls[2]![0] as string
+    expect(sdl).toContain('extend type Query')
+    expect(sdl).toContain('myAuthConfig: AuthConfig!')
   })
 })

--- a/packages/modules/auth/src/graphql/typedefs.ts
+++ b/packages/modules/auth/src/graphql/typedefs.ts
@@ -5,6 +5,8 @@ import { registerTypeDefs } from '@czo/kit/graphql'
 const schemaDir = resolve(import.meta.dirname, 'schema')
 const orgSchema = readFileSync(resolve(schemaDir, 'organization.graphql'), 'utf-8')
 const apiKeySchema = readFileSync(resolve(schemaDir, 'api-key.graphql'), 'utf-8')
+const authConfigSchema = readFileSync(resolve(schemaDir, 'auth-config.graphql'), 'utf-8')
 
 registerTypeDefs(orgSchema)
 registerTypeDefs(apiKeySchema)
+registerTypeDefs(authConfigSchema)

--- a/packages/modules/auth/src/plugins/actor-config.ts
+++ b/packages/modules/auth/src/plugins/actor-config.ts
@@ -1,3 +1,4 @@
+import type { ActorRestrictionConfig } from '../services/auth-restriction-registry'
 import type { ActorTypeOptions } from './actor-type'
 
 export const ACTOR_TYPE_OPTIONS: ActorTypeOptions = {
@@ -14,3 +15,20 @@ export const ACTOR_TYPE_OPTIONS: ActorTypeOptions = {
 export const VALID_ACTORS = new Set(Object.keys(ACTOR_TYPE_OPTIONS.actors))
 
 export type Actor = 'customer' | 'admin'
+
+export const DEFAULT_ACTOR_RESTRICTIONS: Record<Actor, ActorRestrictionConfig> = {
+  customer: {
+    allowedMethods: ['email', 'oauth:google'],
+    priority: 10,
+    require2FA: false,
+    sessionDuration: 604800, // 7 days
+    allowImpersonation: true,
+  },
+  admin: {
+    allowedMethods: ['email', 'oauth:github', 'two-factor'],
+    priority: 100,
+    require2FA: true,
+    sessionDuration: 28800, // 8 hours
+    allowImpersonation: false,
+  },
+}

--- a/packages/modules/auth/src/services/auth-restriction-registry.test.ts
+++ b/packages/modules/auth/src/services/auth-restriction-registry.test.ts
@@ -1,0 +1,304 @@
+import type { ActorRestrictionConfig, ActorTypeProvider } from './auth-restriction-registry'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AuthRestrictionRegistry,
+  DEFAULT_RESTRICTION_CONFIG,
+} from './auth-restriction-registry'
+
+describe('authRestrictionRegistry', () => {
+  let registry: AuthRestrictionRegistry
+
+  beforeEach(() => {
+    registry = new AuthRestrictionRegistry()
+  })
+
+  describe('registerActorType', () => {
+    it('should register a new actor type with config', () => {
+      const config: ActorRestrictionConfig = {
+        allowedMethods: ['email', 'oauth:google'],
+        priority: 10,
+      }
+
+      registry.registerActorType('customer', config)
+
+      expect(registry.getActorConfig('customer')).toBe(config)
+    })
+
+    it('should throw on duplicate actor type registration', () => {
+      const config: ActorRestrictionConfig = {
+        allowedMethods: ['email'],
+        priority: 10,
+      }
+
+      registry.registerActorType('customer', config)
+
+      expect(() => registry.registerActorType('customer', config)).toThrow(
+        'Actor type "customer" is already registered',
+      )
+    })
+
+    it('should throw when registry is frozen', () => {
+      registry.freeze()
+
+      expect(() =>
+        registry.registerActorType('customer', {
+          allowedMethods: ['email'],
+          priority: 10,
+        }),
+      ).toThrow('registry is frozen')
+    })
+  })
+
+  describe('registerActorProvider', () => {
+    it('should register a provider', async () => {
+      const provider: ActorTypeProvider = {
+        actorType: 'customer',
+        hasActorType: vi.fn().mockResolvedValue(true),
+      }
+
+      registry.registerActorProvider(provider)
+
+      await expect(registry.hasActorType('u1', 'customer')).resolves.toBe(true)
+    })
+
+    it('should throw on duplicate provider registration', () => {
+      const provider: ActorTypeProvider = {
+        actorType: 'customer',
+        hasActorType: vi.fn(),
+      }
+
+      registry.registerActorProvider(provider)
+
+      expect(() => registry.registerActorProvider(provider)).toThrow(
+        'Provider for actor type "customer" is already registered',
+      )
+    })
+
+    it('should throw when registry is frozen', () => {
+      registry.freeze()
+
+      expect(() =>
+        registry.registerActorProvider({
+          actorType: 'customer',
+          hasActorType: vi.fn(),
+        }),
+      ).toThrow('registry is frozen')
+    })
+  })
+
+  describe('getActorConfig', () => {
+    it('should return the registered config for known actor types', () => {
+      const config: ActorRestrictionConfig = {
+        allowedMethods: ['email', 'two-factor'],
+        priority: 100,
+        require2FA: true,
+      }
+
+      registry.registerActorType('admin', config)
+
+      expect(registry.getActorConfig('admin')).toBe(config)
+    })
+
+    it('should return DEFAULT_RESTRICTION_CONFIG for unknown actor types', () => {
+      expect(registry.getActorConfig('unknown')).toBe(DEFAULT_RESTRICTION_CONFIG)
+    })
+  })
+
+  describe('isMethodAllowed', () => {
+    it('should return true when method is in allowedMethods', () => {
+      registry.registerActorType('customer', {
+        allowedMethods: ['email', 'oauth:google'],
+        priority: 10,
+      })
+
+      expect(registry.isMethodAllowed('customer', 'email')).toBe(true)
+      expect(registry.isMethodAllowed('customer', 'oauth:google')).toBe(true)
+    })
+
+    it('should return false when method is not in allowedMethods', () => {
+      registry.registerActorType('customer', {
+        allowedMethods: ['email'],
+        priority: 10,
+      })
+
+      expect(registry.isMethodAllowed('customer', 'oauth:github')).toBe(false)
+      expect(registry.isMethodAllowed('customer', 'two-factor')).toBe(false)
+    })
+
+    it('should use default config for unknown actor types', () => {
+      expect(registry.isMethodAllowed('unknown', 'email')).toBe(true)
+      expect(registry.isMethodAllowed('unknown', 'oauth:google')).toBe(false)
+    })
+  })
+
+  describe('hasActorType', () => {
+    it('should delegate to the registered provider', async () => {
+      const hasActorType = vi.fn().mockResolvedValue(true)
+      registry.registerActorProvider({ actorType: 'admin', hasActorType })
+
+      const result = await registry.hasActorType('u1', 'admin')
+
+      expect(result).toBe(true)
+      expect(hasActorType).toHaveBeenCalledWith('u1')
+    })
+
+    it('should return false when no provider is registered', async () => {
+      const result = await registry.hasActorType('u1', 'nonexistent')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getEffectiveConfig', () => {
+    it('should return default config when no providers match', async () => {
+      registry.registerActorProvider({
+        actorType: 'admin',
+        hasActorType: vi.fn().mockResolvedValue(false),
+      })
+
+      const config = await registry.getEffectiveConfig('u1')
+
+      expect(config).toEqual({
+        require2FA: false,
+        sessionDuration: 604800,
+        allowImpersonation: false,
+        dominantActorType: 'unknown',
+        allowedMethods: ['email'],
+        actorTypes: [],
+      })
+    })
+
+    it('should return config for a single matched actor type', async () => {
+      registry.registerActorType('customer', {
+        allowedMethods: ['email', 'oauth:google'],
+        priority: 10,
+        require2FA: false,
+        sessionDuration: 604800,
+        allowImpersonation: true,
+      })
+      registry.registerActorProvider({
+        actorType: 'customer',
+        hasActorType: vi.fn().mockResolvedValue(true),
+      })
+
+      const config = await registry.getEffectiveConfig('u1')
+
+      expect(config).toEqual({
+        require2FA: false,
+        sessionDuration: 604800,
+        allowImpersonation: true,
+        dominantActorType: 'customer',
+        allowedMethods: ['email', 'oauth:google'],
+        actorTypes: ['customer'],
+      })
+    })
+
+    it('should resolve multi-role with most-restrictive-wins', async () => {
+      registry.registerActorType('customer', {
+        allowedMethods: ['email', 'oauth:google'],
+        priority: 10,
+        require2FA: false,
+        sessionDuration: 604800,
+        allowImpersonation: true,
+      })
+      registry.registerActorType('admin', {
+        allowedMethods: ['email', 'oauth:github', 'two-factor'],
+        priority: 100,
+        require2FA: true,
+        sessionDuration: 28800,
+        allowImpersonation: false,
+      })
+      registry.registerActorProvider({
+        actorType: 'customer',
+        hasActorType: vi.fn().mockResolvedValue(true),
+      })
+      registry.registerActorProvider({
+        actorType: 'admin',
+        hasActorType: vi.fn().mockResolvedValue(true),
+      })
+
+      const config = await registry.getEffectiveConfig('u1')
+
+      // require2FA: OR'd → true (admin has it)
+      expect(config.require2FA).toBe(true)
+      // sessionDuration: MIN'd → 28800 (admin's shorter duration)
+      expect(config.sessionDuration).toBe(28800)
+      // allowImpersonation: AND'd → false (admin disallows)
+      expect(config.allowImpersonation).toBe(false)
+      // allowedMethods: intersected → only 'email' (common to both)
+      expect(config.allowedMethods).toEqual(['email'])
+      // dominantActorType: highest priority → admin (100 > 10)
+      expect(config.dominantActorType).toBe('admin')
+      expect(config.actorTypes).toEqual(['customer', 'admin'])
+    })
+
+    it('should handle missing optional fields with defaults', async () => {
+      registry.registerActorType('basic', {
+        allowedMethods: ['email'],
+        priority: 1,
+        // require2FA, sessionDuration, allowImpersonation all undefined
+      })
+      registry.registerActorProvider({
+        actorType: 'basic',
+        hasActorType: vi.fn().mockResolvedValue(true),
+      })
+
+      const config = await registry.getEffectiveConfig('u1')
+
+      expect(config.require2FA).toBe(false)
+      expect(config.sessionDuration).toBe(604800) // default
+      expect(config.allowImpersonation).toBe(false) // undefined !== true
+    })
+  })
+
+  describe('getRegisteredActorTypes', () => {
+    it('should return empty array when no types registered', () => {
+      expect(registry.getRegisteredActorTypes()).toEqual([])
+    })
+
+    it('should return all registered actor types', () => {
+      registry.registerActorType('customer', { allowedMethods: ['email'], priority: 10 })
+      registry.registerActorType('admin', { allowedMethods: ['email'], priority: 100 })
+
+      const types = registry.getRegisteredActorTypes()
+
+      expect(types).toEqual(['customer', 'admin'])
+    })
+  })
+
+  describe('freeze / isFrozen', () => {
+    it('should start unfrozen', () => {
+      expect(registry.isFrozen()).toBe(false)
+    })
+
+    it('should be frozen after freeze()', () => {
+      registry.freeze()
+
+      expect(registry.isFrozen()).toBe(true)
+    })
+
+    it('should still allow reads after freeze', () => {
+      registry.registerActorType('customer', {
+        allowedMethods: ['email'],
+        priority: 10,
+      })
+      registry.freeze()
+
+      expect(registry.getActorConfig('customer')).toBeDefined()
+      expect(registry.isMethodAllowed('customer', 'email')).toBe(true)
+      expect(registry.getRegisteredActorTypes()).toEqual(['customer'])
+    })
+  })
+
+  describe('singleton', () => {
+    it('should return the same instance on repeated calls', async () => {
+      vi.resetModules()
+      const { useAuthRestrictionRegistry } = await import('./auth-restriction-registry')
+
+      const a = useAuthRestrictionRegistry()
+      const b = useAuthRestrictionRegistry()
+
+      expect(a).toBe(b)
+    })
+  })
+})

--- a/packages/modules/auth/src/services/auth-restriction-registry.ts
+++ b/packages/modules/auth/src/services/auth-restriction-registry.ts
@@ -1,0 +1,152 @@
+// ─── Types ────────────────────────────────────────────────────────────
+
+export type AuthMethod = 'email' | 'two-factor' | `oauth:${string}`
+
+export interface ActorRestrictionConfig {
+  allowedMethods: readonly AuthMethod[]
+  priority: number
+  require2FA?: boolean
+  sessionDuration?: number
+  allowImpersonation?: boolean
+}
+
+export interface ActorTypeProvider {
+  actorType: string
+  hasActorType: (userId: string) => Promise<boolean>
+}
+
+export interface EffectiveAuthConfig {
+  require2FA: boolean
+  sessionDuration: number
+  allowImpersonation: boolean
+  dominantActorType: string
+  allowedMethods: string[]
+  actorTypes: string[]
+}
+
+// ─── Defaults ─────────────────────────────────────────────────────────
+
+const DEFAULT_SESSION_DURATION = 604800 // 7 days
+
+export const DEFAULT_RESTRICTION_CONFIG: ActorRestrictionConfig = {
+  allowedMethods: ['email'],
+  priority: 0,
+  require2FA: false,
+  sessionDuration: DEFAULT_SESSION_DURATION,
+  allowImpersonation: false,
+}
+
+// ─── Registry ─────────────────────────────────────────────────────────
+
+export class AuthRestrictionRegistry {
+  private readonly configs = new Map<string, ActorRestrictionConfig>()
+  private readonly providers = new Map<string, ActorTypeProvider>()
+  private frozen = false
+
+  registerActorType(actorType: string, config: ActorRestrictionConfig): void {
+    if (this.frozen) {
+      throw new Error(`Cannot register actor type "${actorType}" — registry is frozen`)
+    }
+    if (this.configs.has(actorType)) {
+      throw new Error(`Actor type "${actorType}" is already registered`)
+    }
+    this.configs.set(actorType, config)
+  }
+
+  registerActorProvider(provider: ActorTypeProvider): void {
+    if (this.frozen) {
+      throw new Error(`Cannot register provider for "${provider.actorType}" — registry is frozen`)
+    }
+    if (this.providers.has(provider.actorType)) {
+      throw new Error(`Provider for actor type "${provider.actorType}" is already registered`)
+    }
+    this.providers.set(provider.actorType, provider)
+  }
+
+  getActorConfig(actorType: string): ActorRestrictionConfig {
+    return this.configs.get(actorType) ?? DEFAULT_RESTRICTION_CONFIG
+  }
+
+  isMethodAllowed(actorType: string, method: AuthMethod): boolean {
+    const config = this.getActorConfig(actorType)
+    return config.allowedMethods.includes(method)
+  }
+
+  async hasActorType(userId: string, actorType: string): Promise<boolean> {
+    const provider = this.providers.get(actorType)
+    if (!provider) {
+      return false
+    }
+    return provider.hasActorType(userId)
+  }
+
+  async getEffectiveConfig(userId: string): Promise<EffectiveAuthConfig> {
+    const matchedTypes: string[] = []
+    const matchedConfigs: ActorRestrictionConfig[] = []
+
+    for (const [actorType, provider] of this.providers) {
+      if (await provider.hasActorType(userId)) {
+        matchedTypes.push(actorType)
+        matchedConfigs.push(this.getActorConfig(actorType))
+      }
+    }
+
+    if (matchedConfigs.length === 0) {
+      return {
+        require2FA: DEFAULT_RESTRICTION_CONFIG.require2FA ?? false,
+        sessionDuration: DEFAULT_RESTRICTION_CONFIG.sessionDuration ?? DEFAULT_SESSION_DURATION,
+        allowImpersonation: DEFAULT_RESTRICTION_CONFIG.allowImpersonation ?? false,
+        dominantActorType: 'unknown',
+        allowedMethods: DEFAULT_RESTRICTION_CONFIG.allowedMethods,
+        actorTypes: [],
+      }
+    }
+
+    // Most-restrictive-wins: OR require2FA, MIN sessionDuration, AND allowImpersonation, intersect methods
+    const require2FA = matchedConfigs.some(c => c.require2FA === true)
+    const sessionDuration = Math.min(
+      ...matchedConfigs.map(c => c.sessionDuration ?? DEFAULT_SESSION_DURATION),
+    )
+    const allowImpersonation = matchedConfigs.every(c => c.allowImpersonation === true)
+
+    // Intersect allowedMethods across all matched configs
+    let allowedMethods: string[] = [...matchedConfigs[0]!.allowedMethods]
+    for (let i = 1; i < matchedConfigs.length; i++) {
+      const methodSet = new Set<string>(matchedConfigs[i]!.allowedMethods)
+      allowedMethods = allowedMethods.filter(m => methodSet.has(m))
+    }
+
+    // Dominant = highest priority
+    const dominantIdx = matchedConfigs.reduce(
+      (maxIdx, c, idx) => (c.priority > matchedConfigs[maxIdx]!.priority ? idx : maxIdx),
+      0,
+    )
+
+    return {
+      require2FA,
+      sessionDuration,
+      allowImpersonation,
+      dominantActorType: matchedTypes[dominantIdx]!,
+      allowedMethods,
+      actorTypes: matchedTypes,
+    }
+  }
+
+  getRegisteredActorTypes(): string[] {
+    return [...this.configs.keys()]
+  }
+
+  freeze(): void {
+    this.frozen = true
+  }
+
+  isFrozen(): boolean {
+    return this.frozen
+  }
+}
+
+// ─── Singleton ────────────────────────────────────────────────────────
+
+export function useAuthRestrictionRegistry(): AuthRestrictionRegistry {
+  return ((useAuthRestrictionRegistry as any).__instance__ ??= new AuthRestrictionRegistry())
+}

--- a/packages/modules/auth/src/types.ts
+++ b/packages/modules/auth/src/types.ts
@@ -1,4 +1,5 @@
 import type { Auth } from './config/auth.config'
+import type { AuthRestrictionRegistry } from './services/auth-restriction-registry'
 
 export interface AuthContext {
   session: {
@@ -23,5 +24,6 @@ export interface AuthContext {
 export interface GraphQLContext {
   auth: AuthContext
   authInstance: Auth
+  authRestrictions: AuthRestrictionRegistry
   request: Request
 }


### PR DESCRIPTION
## Summary

- Add `AuthRestrictionRegistry` singleton service that enforces per-actor-type auth restrictions (allowed methods, 2FA, session duration, impersonation)
- Registry freezes on `czo:boot` hook to prevent late mutations; default restrictions for `customer` and `admin` actor types
- Validate auth method in `session.create.before` hook — rejects disallowed methods with `auth.restriction.denied` event
- Most-restrictive-wins resolution for multi-role users (OR require2FA, MIN sessionDuration, AND allowImpersonation, intersect allowedMethods)
- GraphQL `myAuthConfig` query exposing effective config to the frontend

## Test plan

- [x] 374 tests passing across 21 test suites
- [x] Registry: register, duplicate rejection, freeze throws, getActorConfig fallback, isMethodAllowed, hasActorType delegation, getEffectiveConfig multi-role, singleton
- [x] Auth config: session rejects disallowed method, emits event, allows valid method, skips validation without registry
- [x] Events: `restrictionDenied()` publishes correctly, AUTH_EVENTS.RESTRICTION_DENIED exists
- [x] GraphQL: `myAuthConfig` resolver returns effective config, `auth-config.graphql` registered
- [x] Lint clean (`--max-warnings 0`), auth build, mazo build all pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)