### PR TITLE
feat(auth): add dead letter queue retention for webhook deliveries

### DIFF
--- a/packages/modules/auth/src/listeners/webhook.listener.test.ts
+++ b/packages/modules/auth/src/listeners/webhook.listener.test.ts
@@ -204,7 +204,11 @@ describe('registerWebhookDispatcher', () => {
         targetUrl: 'https://example.com/hook',
         event: 'products.created',
       }),
-      expect.objectContaining({ attempts: 3, backoff: { type: 'exponential', delay: 1000 } }),
+      expect.objectContaining({
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnFail: { count: 1000 },
+      }),
     )
   })
 

--- a/packages/modules/auth/src/listeners/webhook.listener.ts
+++ b/packages/modules/auth/src/listeners/webhook.listener.ts
@@ -244,6 +244,7 @@ export async function registerWebhookDispatcher(): Promise<void> {
       }, {
         attempts: 3,
         backoff: { type: 'exponential', delay: 1000 },
+        removeOnFail: { count: 1000 },
       })
 
       logger.info(`Webhook job enqueued for app "${app.appId}" event "${domainEvent.type}" (${deliveryId})`)


### PR DESCRIPTION
## Summary

- Adds `removeOnFail: { count: 1000 }` to the BullMQ webhook delivery queue, retaining the last 1000 failed jobs as a dead letter queue
- Updates existing test assertion to verify the DLQ option is passed through
- Completes all 6 acceptance criteria for #35

Closes #35

## Test plan

- [x] All 513 auth module tests pass (`pnpm test` in `packages/modules/auth`)
- [ ] Verify lint passes (`pnpm lint`)
- [ ] Verify build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)